### PR TITLE
Add System.Attribute to allow creation of custom attributes

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Core.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Core.lua
@@ -916,13 +916,7 @@ defCls("System.ValueType", ValueType)
 local AnonymousType = {}
 defCls("System.AnonymousType", AnonymousType)
 
-local Attribute = {
-  __kind__ = "C",
-  __default__ = function(cls)
-    return setmetatale({}, cls)
-  end
-}
-defCls("System.Attribute", Attribute)
+defCls("System.Attribute", {})
 
 function System.anonymousType(t)
   return setmetatable(t, AnonymousType)

--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Core.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Core.lua
@@ -916,6 +916,14 @@ defCls("System.ValueType", ValueType)
 local AnonymousType = {}
 defCls("System.AnonymousType", AnonymousType)
 
+local Attribute = {
+  __kind__ = "C",
+  __default__ = function(cls)
+    return setmetatale({}, cls)
+  end
+}
+defCls("System.Attribute", Attribute)
+
 function System.anonymousType(t)
   return setmetatable(t, AnonymousType)
 end


### PR DESCRIPTION
I noticed while working on a project that System.Attribute was not implemented in the core library, so here's a tiny implementation.