### PR TITLE
Fixed an issue where undefined variables were used in System.usingDeclare

### DIFF
--- a/CSharp.lua/LuaAst/LuaCompilationUnitSyntax.cs
+++ b/CSharp.lua/LuaAst/LuaCompilationUnitSyntax.cs
@@ -86,42 +86,83 @@ namespace CSharpLua.LuaAst {
       }
     }
 
-    private void CheckUsingDeclares() {
+    /// <summary>
+    /// Sorts and adds all using statements at the start of the file to the Lua file and adds a call to System.usingDeclare to define the variabeles created.
+    /// </summary>
+    private void CheckUsingDeclares()
+    {
       var imports = usingDeclares_.Where(i => !i.IsFromCode).ToList();
-      if (imports.Count > 0) {
+      if (imports.Count > 0)
+      {
         imports.Sort((x, y) => x.Prefix.CompareTo(y.Prefix));
-        foreach (var import in imports) {
+        foreach (var import in imports)
+        {
           AddImport(new LuaIdentifierNameSyntax(import.NewPrefix), new LuaIdentifierNameSyntax(import.Prefix));
         }
       }
 
+      // Get all using statements in the file
       var usingDeclares = usingDeclares_.Where(i => i.IsFromCode).ToList();
-      if (usingDeclares.Count > 0) {
+      if (usingDeclares.Count > 0)
+      {
+
+        // Sort all using statements
         usingDeclares.Sort((x, y) => x.Prefix.CompareTo(y.Prefix));
-        foreach (var usingDeclare in usingDeclares) {
-          AddImport(new LuaIdentifierNameSyntax(usingDeclare.NewPrefix), null);
+
+        // Insert an local variabele definition for each using statement
+        foreach (var usingDeclare in usingDeclares)
+        {
+          AddImport(new LuaIdentifierNameSyntax(usingDeclare.NewPrefix), null); // local Import
         }
 
+        // Create the System.usingDeclare anonymous function for this Lua file
         var global = LuaIdentifierNameSyntax.Global;
         LuaFunctionExpressionSyntax functionExpression = new LuaFunctionExpressionSyntax();
+        // Add the global parameter to the function we can use for accessing namespaces
         functionExpression.AddParameter(global);
-        foreach (var usingDeclare in usingDeclares) {
-          if (usingDeclare.Prefix != usingDeclare.NewPrefix) {
-            LuaAssignmentExpressionSyntax assignment = new LuaAssignmentExpressionSyntax(new LuaIdentifierNameSyntax(usingDeclare.NewPrefix), new LuaIdentifierNameSyntax(usingDeclare.Prefix));
-            functionExpression.Body.Statements.Add(new LuaExpressionStatementSyntax(assignment));
-          } else {
-            LuaMemberAccessExpressionSyntax right = new LuaMemberAccessExpressionSyntax(global, new LuaIdentifierNameSyntax(usingDeclare.Prefix));
-            LuaAssignmentExpressionSyntax assignment = new LuaAssignmentExpressionSyntax(new LuaIdentifierNameSyntax(usingDeclare.NewPrefix), right);
-            functionExpression.Body.Statements.Add(new LuaExpressionStatementSyntax(assignment));
+
+        // Determine how each local variabele we created for each usingDeclare will be defined
+        foreach (var usingDeclare in usingDeclares)
+        {
+          LuaAssignmentExpressionSyntax assignment;
+
+          var root = "";
+          try
+          {
+            // Find the string representation of the root namepsace of the usingdeclare
+            root = usingDeclare.Prefix.Substring(0, usingDeclare.Prefix.IndexOf('.'));
           }
+          catch (ArgumentOutOfRangeException)
+          {
+          }
+
+          // If the using declare is a root namespace
+          if (usingDeclare.Prefix == usingDeclare.NewPrefix
+              // or No parent namespace of the current using declare was defined
+              || !usingDeclares.Exists(x => x.Prefix == root))
+          {
+            // Global is needed to find the namespace
+            LuaMemberAccessExpressionSyntax right = new LuaMemberAccessExpressionSyntax(global, new LuaIdentifierNameSyntax(usingDeclare.Prefix));
+            assignment = new LuaAssignmentExpressionSyntax(new LuaIdentifierNameSyntax(usingDeclare.NewPrefix), right);
+          }
+          else
+          {
+            // A usingdeclare of the root namespace of the current usingdeclare was found, so no need to use global
+            assignment = new LuaAssignmentExpressionSyntax(new LuaIdentifierNameSyntax(usingDeclare.NewPrefix), new LuaIdentifierNameSyntax(usingDeclare.Prefix));
+          }
+
+          // Add the local variabele assignment to the usingDeclare function body
+          functionExpression.Body.Statements.Add(new LuaExpressionStatementSyntax(assignment));
         }
 
+        // End the anonymous function we passed to System.usingDeclare and close the parameter bracket
         LuaInvocationExpressionSyntax invocationExpression = new LuaInvocationExpressionSyntax(LuaIdentifierNameSyntax.UsingDeclare, functionExpression);
         importAreaStatements.Statements.Add(new LuaExpressionStatementSyntax(invocationExpression));
       }
 
       int index = Statements.FindIndex(i => i is LuaNamespaceDeclarationSyntax);
-      if (index != -1) {
+      if (index != -1)
+      {
         Statements.Insert(index, importAreaStatements);
       }
     }

--- a/CSharp.lua/LuaAst/LuaCompilationUnitSyntax.cs
+++ b/CSharp.lua/LuaAst/LuaCompilationUnitSyntax.cs
@@ -147,7 +147,7 @@ namespace CSharpLua.LuaAst {
         // If the using declare is a root namespace
         if (usingDeclare.Prefix == usingDeclare.NewPrefix
             // or No parent namespace of the current using declare was defined
-            || !usingDeclares.Exists(x => x.Prefix == root))
+            || !usingDeclares_.Exists(x => x.Prefix == root))
         {
           // Global is needed to find the namespace
           LuaMemberAccessExpressionSyntax right = new LuaMemberAccessExpressionSyntax(global, new LuaIdentifierNameSyntax(usingDeclare.Prefix));


### PR DESCRIPTION
I encountered an issue where the compiler would use undefined variables if a C# file has a using statement in it which referenced a sub-namespace, without also having a using statement for the root namespace.

Example C#:

Test/Program.cs

	using Test.Test2;

	namespace Test
	{
		class Program
		{
			static void Main(string[] args)
			{
				
			}
		}

		public abstract class Class
		{
			public int RandomInt { get; } = Class2.RandomInt;
		}
	}



Test/Test2/Class2.cs

	namespace Test.Test2
	{
		public class Class2
		{
			public static int RandomInt { get; } = 1;
		}
	}


This code would compile to:

Test/Program.lua

	-- Generated by CSharp.lua Compiler 1.1.0
	local System = System
	local TestTest2
	System.usingDeclare(function (global) 
		TestTest2 = Test.Test2 -- undefined variable Test <---
	end)
	System.namespace("Test", function (namespace) 
		namespace.class("Program", function (namespace) 
			local Main
			Main = function (args) 
			end
			return {
				Main = Main
			}
		end)

		namespace.class("Class", function (namespace) 
			local __ctor__
			__ctor__ = function (this) 
				this.RandomInt = TestTest2.Class2.RandomInt
			end
			return {
				__ctor__ = __ctor__
			}
		end)
	end)


Test/Test2/Class2.lua

	-- Generated by CSharp.lua Compiler 1.1.0
	local System = System
	System.namespace("Test.Test2", function (namespace) 
		namespace.class("Class2", function (namespace) 
			local RandomInt
			return {
				RandomInt = 1
			}
		end)
	end)

Notice that a variable 'Test' is used, without it being defined.

If I add `using Test;` at the top of Test/Program.cs, `Test = global.Test` would be added, and the code would work.

I noticed the issue was the `CheckUsingDeclares` function not checking if the root namespace of a using statement referencing a sub-namespace was defined, and just assumed it was.

Lua code after changes:

Test/Program.lua

	-- Generated by CSharp.lua Compiler 1.1.0
	local System = System
	local TestTest2
	System.usingDeclare(function (global) 
		TestTest2 = global.Test.Test2 -- namespace Test is accessed via global <---
	end)
	System.namespace("Test", function (namespace) 
		namespace.class("Program", function (namespace) 
			local Main
			Main = function (args) 
			end
			return {
				Main = Main
			}
		end)

		namespace.class("Class", function (namespace) 
			local __ctor__
			__ctor__ = function (this) 
				this.RandomInt = TestTest2.Class2.RandomInt
			end
			return {
				__ctor__ = __ctor__
			}
		end)
	end)


Test/Test2/Class2.lua

	-- Generated by CSharp.lua Compiler 1.1.0
	local System = System
	System.namespace("Test.Test2", function (namespace) 
		namespace.class("Class2", function (namespace) 
			local RandomInt
			return {
				RandomInt = 1
			}
		end)
	end)

The proposed code now checks if a reference to the root namespace was found, and uses it if so.
Else it will compile defining the sub-namespace using global.

