### PR TITLE
Fixed invalid return value on custom attributes

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
@@ -219,7 +219,7 @@ local FieldInfo = define("System.Reflection.FieldInfo", {
         index = 5
       end
       fillMetadataCustomAttributes(t, metadata, index, attributeType)
-    endS
+    end
     return arrayFromTable(t, System.Attribute) 
   end
 })

--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
@@ -218,8 +218,8 @@ local FieldInfo = define("System.Reflection.FieldInfo", {
       if type(metadata[index]) == "string" then
         index = 5
       end
-      return fillMetadataCustomAttributes(t, metadata, index, attributeType)
-    end
+      fillMetadataCustomAttributes(t, metadata, index, attributeType)
+    endS
     return arrayFromTable(t, System.Attribute) 
   end
 })
@@ -352,7 +352,7 @@ local PropertyInfo = define("System.Reflection.PropertyInfo", {
     local metadata = this.metadata
     if metadata then
       local index = getPropertyAttributesIndex(metadata)
-      return fillMetadataCustomAttributes(t, metadata, index, attributeType)
+      fillMetadataCustomAttributes(t, metadata, index, attributeType)
     end
     return arrayFromTable(t, System.Attribute) 
   end
@@ -466,7 +466,7 @@ local MethodInfo = define("System.Reflection.MethodInfo", {
     local metadata = this.metadata
     if metadata then
       local index = getMethodAttributesIndex(metadata)
-      return fillMetadataCustomAttributes(t, metadata, index, attributeType)
+      fillMetadataCustomAttributes(t, metadata, index, attributeType)
     end
     return arrayFromTable(t, System.Attribute)
   end


### PR DESCRIPTION
The ``fillMetadataCustomAttributes`` method was used incorrectly as functions returned the result while it actually fills a table