### PR TITLE
Fixed missing tuple getRest()

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Core.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Core.lua
@@ -1234,13 +1234,18 @@ local function tupleGet(t, index)
   return t[index + 1]
 end
 
+local function tupleGetRest(t)
+  return t[8]
+end
+
 local Tuple = { 
   Deconstruct = tupleDeconstruct,
   ToString = tupleToString,
   EqualsObj = tupleEqualsObj,
   CompareToObj = tupleCompareToObj,
   getLength = tupleLength,
-  get = tupleGet
+  get = tupleGet,
+  getRest = tupleGetRest
 }
 
 defCls("System.Tuple", Tuple)


### PR DESCRIPTION
Accessing the `Rest` property on a tuple parsed a method that didn't exist within the core system.