### PR TITLE
Implement single output file generation.

### DIFF
--- a/CSharp.lua/Compiler.cs
+++ b/CSharp.lua/Compiler.cs
@@ -132,6 +132,14 @@ namespace CSharpLua {
     }
 
     public void Compile() {
+      GetGenerator().Generate(output_);
+    }
+
+    public void CompileSingleFile(string fileName, IEnumerable<string> luaSystemLibs) {
+      GetGenerator().GenerateSingleFile(fileName, output_, luaSystemLibs);
+    }
+
+    private LuaSyntaxGenerator GetGenerator() {
       var files = Directory.EnumerateFiles(folder_, "*.cs", SearchOption.AllDirectories);
       var codes = files.Select(i => (File.ReadAllText(i), i));
       var libs = GetLibs(libs_, out var luaModuleLibs);
@@ -146,8 +154,7 @@ namespace CSharpLua {
         IsInlineSimpleProperty = IsInlineSimpleProperty,
         IsPreventDebugObject = IsPreventDebugObject,
       };
-      var generator = Build(cscArguments_, codes, libs, Metas, setting);
-      generator.Generate(output_);
+      return Build(cscArguments_, codes, libs, Metas, setting);
     }
 
     public static string CompileSingleCode(string code) {

--- a/CSharp.lua/LuaSyntaxGenerator.cs
+++ b/CSharp.lua/LuaSyntaxGenerator.cs
@@ -108,6 +108,8 @@ namespace CSharpLua {
       }
     }
 
+    public const string kManifestFuncName = "InitCSharp";
+
     private const string kLuaSuffix = ".lua";
     private static readonly Encoding Encoding = new UTF8Encoding(false);
 
@@ -197,11 +199,70 @@ namespace CSharpLua {
     public void Generate(string outFolder) {
       List<string> modules = new List<string>();
       foreach (var luaCompilationUnit in Create()) {
-        string outFile = GetOutFilePath(luaCompilationUnit.FilePath, outFolder, out string module);
+        string outFile = GetOutFileAbsolutePath(luaCompilationUnit.FilePath, outFolder, out string module);
         Write(luaCompilationUnit, outFile);
         modules.Add(module);
       }
       ExportManifestFile(modules, outFolder);
+    }
+
+    public void GenerateSingleFile(string outFile, string outFolder, IEnumerable<string> luaSystemLibs) {
+      outFile = GetOutFileRelativePath(outFile, outFolder, out _);
+      using (var streamWriter = new StreamWriter(outFile, false, Encoding)) {
+        foreach (var luaSystemLib in luaSystemLibs) {
+          WriteLuaSystemLib(luaSystemLib, streamWriter);
+        }
+        foreach (var luaCompilationUnit in Create()) {
+          WriteCompilationUnit(luaCompilationUnit, streamWriter);
+        }
+        if (mainEntryPoint_ is null) {
+          throw new CompilationErrorException("Program has no main entry point.");
+        }
+        WriteManifest(streamWriter);
+      }
+    }
+
+    private void WriteLuaSystemLib(string filePath, TextWriter writer) {
+      writer.WriteLine(LuaSyntaxNode.Keyword.Do);
+      writer.WriteLine(File.ReadAllText(filePath));
+      writer.WriteLine(LuaSyntaxNode.Keyword.End);
+    }
+
+    private void WriteCompilationUnit(LuaCompilationUnitSyntax luaCompilationUnit, TextWriter writer) {
+      writer.WriteLine(LuaSyntaxNode.Keyword.Do);
+      Write(luaCompilationUnit, writer);
+      writer.WriteLine();
+      writer.WriteLine(LuaSyntaxNode.Keyword.End);
+    }
+
+    private void WriteManifest(TextWriter writer) {
+      const string kInit = "System.init";
+      var types = GetExportTypes();
+      if (types.Count > 0) {
+        var functionExpression = new LuaFunctionExpressionSyntax();
+        var initCSharpFunctionDeclarationStatement = new LuaLocalVariablesStatementSyntax();
+        initCSharpFunctionDeclarationStatement.Initializer = new LuaEqualsValueClauseListSyntax(new[] { functionExpression });
+        initCSharpFunctionDeclarationStatement.Variables.Add(new LuaSymbolNameSyntax(new LuaIdentifierLiteralExpressionSyntax(kManifestFuncName)));
+
+        LuaTableExpression typeTable = new LuaTableExpression();
+        foreach (var type in types) {
+          LuaIdentifierNameSyntax typeName = GetTypeShortName(type);
+          typeTable.Add(new LuaStringLiteralExpressionSyntax(typeName));
+        }
+
+        var methodName = mainEntryPoint_.Name;
+        var methodTypeName = GetTypeName(mainEntryPoint_.ContainingType);
+        var entryPointInvocation = new LuaInvocationExpressionSyntax(new LuaMemberAccessExpressionSyntax(methodTypeName, methodName));
+
+        functionExpression.AddStatement(new LuaInvocationExpressionSyntax(kInit, typeTable));
+        functionExpression.AddStatement(entryPointInvocation);
+
+        LuaCompilationUnitSyntax luaCompilationUnit = new LuaCompilationUnitSyntax();
+        luaCompilationUnit.AddStatement(new LuaLocalDeclarationStatementSyntax(initCSharpFunctionDeclarationStatement));
+
+        Write(luaCompilationUnit, writer);
+        writer.WriteLine();
+      }
     }
 
     public string GenerateSingle() {
@@ -219,8 +280,11 @@ namespace CSharpLua {
       return patrh.Remove(0, Setting.BaseFolder.Length).TrimStart(Path.DirectorySeparatorChar, '/');
     }
 
-    private string GetOutFilePath(string inFilePath, string output_, out string module) {
-      string path = RemoveBaseFolder(inFilePath);
+    private string GetOutFileAbsolutePath(string inFilePath, string output_, out string module) {
+      return GetOutFileRelativePath(RemoveBaseFolder(inFilePath), output_, out module);
+    }
+
+    private string GetOutFileRelativePath(string path, string output_, out string module) {
       string extend = Path.GetExtension(path);
       path = path.Remove(path.Length - extend.Length, extend.Length);
       path = path.Replace('.', '_');


### PR DESCRIPTION
This feature adds a new compile method that puts all lua code in a single file.
This is useful for example when using the compiler for Warcraft III maps, where all code must be in a single file called "war3map.lua".

Example:
Using:
compiler.CompileSingleFile("war3map", CoreSystemProvider.GetCoreSystemFiles());
The result is:
https://pastebin.com/h2CpD428
(note: the pastebin code has slightly altered CoreSystem.Lua files, and also the functions 'main' and 'config' at the bottom are not generated by this method).