### PR TITLE
Implement compiling with .csproj input.

### DIFF
--- a/CSharp.lua/CSharp.lua.csproj
+++ b/CSharp.lua/CSharp.lua.csproj
@@ -14,6 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cake.Common" Version="0.35.0" />
+    <PackageReference Include="Cake.Incubator" Version="5.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
   </ItemGroup>
 

--- a/CSharp.lua/CSharp.lua.csproj
+++ b/CSharp.lua/CSharp.lua.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Cake.Common" Version="0.35.0" />
     <PackageReference Include="Cake.Incubator" Version="5.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
+    <PackageReference Include="NuGet.Packaging" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharp.lua/CSharp.lua.csproj
+++ b/CSharp.lua/CSharp.lua.csproj
@@ -11,6 +11,7 @@
     <PackageProjectUrl>https://github.com/yanghuan/CSharp.lua</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/yanghuan/CSharp.lua/master/LICENSE</PackageLicenseUrl>
     <LangVersion>latest</LangVersion>
+    <RootNamespace>CSharpLua</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharp.lua/Compiler.cs
+++ b/CSharp.lua/Compiler.cs
@@ -179,8 +179,7 @@ namespace CSharpLua {
     }
 
     private IEnumerable<string> GetFiles(IEnumerable<(string folder, CustomProjectParserResult project)> projects) {
-      // TODO: don't return bin/obj contents
-      return projects.SelectMany(project => Directory.EnumerateFiles(project.folder, "*.cs", SearchOption.AllDirectories));
+      return projects.SelectMany(project => project.project.EnumerateSourceFiles(project.folder));
     }
 
     public static string CompileSingleCode(string code) {

--- a/CSharp.lua/Compiler.cs
+++ b/CSharp.lua/Compiler.cs
@@ -29,7 +29,8 @@ namespace CSharpLua {
     private const string kSystemMeta = "~/System.xml";
     private const char kLuaModuleSuffix = '!';
 
-    private readonly string folder_;
+    private readonly bool isProject_;
+    private readonly string input_;
     private readonly string output_;
     private readonly string[] libs_;
     private readonly string[] metas_;
@@ -43,8 +44,9 @@ namespace CSharpLua {
     public bool IsInlineSimpleProperty { get; set; }
     public bool IsPreventDebugObject { get; set; }
 
-    public Compiler(string folder, string output, string lib, string meta, string csc, bool isClassic, string atts, string enums) {
-      folder_ = folder;
+    public Compiler(string input, string output, string lib, string meta, string csc, bool isClassic, string atts, string enums) {
+      isProject_ = new FileInfo(input).Extension.ToLower() == ".csproj";
+      input_ = input;
       output_ = output;
       libs_ = Utility.Split(lib);
       metas_ = Utility.Split(meta);
@@ -140,7 +142,7 @@ namespace CSharpLua {
     }
 
     private LuaSyntaxGenerator GetGenerator() {
-      var files = Directory.EnumerateFiles(folder_, "*.cs", SearchOption.AllDirectories);
+      var files = Directory.EnumerateFiles(input_, "*.cs", SearchOption.AllDirectories);
       var codes = files.Select(i => (File.ReadAllText(i), i));
       var libs = GetLibs(libs_, out var luaModuleLibs);
       var setting = new LuaSyntaxGenerator.SettingInfo() {
@@ -153,7 +155,7 @@ namespace CSharpLua {
         IsInlineSimpleProperty = IsInlineSimpleProperty,
         IsPreventDebugObject = IsPreventDebugObject,
       };
-      setting.AddBaseFolder(folder_);
+      setting.AddBaseFolder(input_);
       return Build(cscArguments_, codes, libs, Metas, setting);
     }
 

--- a/CSharp.lua/Compiler.cs
+++ b/CSharp.lua/Compiler.cs
@@ -146,7 +146,6 @@ namespace CSharpLua {
       var setting = new LuaSyntaxGenerator.SettingInfo() {
         IsClassic = isClassic_,
         IsExportMetadata = IsExportMetadata,
-        BaseFolder = folder_,
         Attributes = attributes_,
         Enums = enums_,
         LuaModuleLibs = new HashSet<string>(luaModuleLibs),
@@ -154,6 +153,7 @@ namespace CSharpLua {
         IsInlineSimpleProperty = IsInlineSimpleProperty,
         IsPreventDebugObject = IsPreventDebugObject,
       };
+      setting.AddBaseFolder(folder_);
       return Build(cscArguments_, codes, libs, Metas, setting);
     }
 

--- a/CSharp.lua/Compiler.cs
+++ b/CSharp.lua/Compiler.cs
@@ -150,8 +150,7 @@ namespace CSharpLua {
       var projects = mainProject?.EnumerateProjects().ToArray();
       var files = isProject_ ? GetFiles(projects) : GetFiles();
       var codes = files.Select(i => (File.ReadAllText(i), i));
-      // TODO: implement GetLibs for projects
-      var libs = isProject_ ? GetLibs(libs_, out var luaModuleLibs) : GetLibs(libs_, out luaModuleLibs);
+      var libs = GetLibs(libs_, out var luaModuleLibs);
       var setting = new LuaSyntaxGenerator.SettingInfo() {
         IsClassic = isClassic_,
         IsExportMetadata = IsExportMetadata,

--- a/CSharp.lua/Compiler.cs
+++ b/CSharp.lua/Compiler.cs
@@ -164,7 +164,7 @@ namespace CSharpLua {
         foreach (var package in packages) {
           var packageFiles = PackageHelper.EnumerateSourceFiles(package, out var baseFolder).ToArray();
           if (packageFiles.Length > 0) {
-            files.Concat(packageFiles);
+            files = files.Concat(packageFiles);
             packageBaseFolders.Add(baseFolder);
           }
         }

--- a/CSharp.lua/Compiler.cs
+++ b/CSharp.lua/Compiler.cs
@@ -144,11 +144,9 @@ namespace CSharpLua {
     }
 
     private LuaSyntaxGenerator GetGenerator() {
-      // TODO: configure configuration
-      const bool isDebug = true;
       const string configurationDebug = "Debug";
       const string configurationRelease = "Release";
-      var mainProject = isProject_ ? ProjectHelper.ParseProject(input_, isDebug ? configurationDebug : configurationRelease) : null;
+      var mainProject = isProject_ ? ProjectHelper.ParseProject(input_, IsCompileDebug() ? configurationDebug : configurationRelease) : null;
       var projects = mainProject?.EnumerateProjects().ToArray();
       var files = isProject_ ? GetFiles(projects) : GetFiles();
       var codes = files.Select(i => (File.ReadAllText(i), i));
@@ -180,6 +178,15 @@ namespace CSharpLua {
 
     private IEnumerable<string> GetFiles(IEnumerable<(string folder, CustomProjectParserResult project)> projects) {
       return projects.SelectMany(project => project.project.EnumerateSourceFiles(project.folder));
+    }
+
+    private bool IsCompileDebug() {
+      foreach (var arg in cscArguments_) {
+        if (arg.StartsWith("-debug")) {
+          return true;
+        }
+      }
+      return false;
     }
 
     public static string CompileSingleCode(string code) {

--- a/CSharp.lua/LuaSyntaxGenerator.cs
+++ b/CSharp.lua/LuaSyntaxGenerator.cs
@@ -142,7 +142,7 @@ namespace CSharpLua {
 
       public string GetBaseFolder(string path) {
         foreach (var baseFolder in BaseFolders) {
-          if (path.StartsWith(baseFolder)) {
+          if (path.StartsWith(baseFolder + Path.DirectorySeparatorChar)) {
             return baseFolder;
           }
         }

--- a/CSharp.lua/LuaSyntaxGenerator.cs
+++ b/CSharp.lua/LuaSyntaxGenerator.cs
@@ -57,6 +57,7 @@ namespace CSharpLua {
       public string IndentString { get; private set; }
       public bool IsClassic { get; set; }
       public bool IsExportMetadata { get; set; }
+      [Obsolete]
       public string BaseFolder {
         get => BaseFolders.SingleOrDefault() ?? string.Empty;
         set { BaseFolders.Clear(); BaseFolders.Add(value); } }
@@ -306,8 +307,8 @@ namespace CSharpLua {
       throw new InvalidProgramException();
     }
 
-    internal string RemoveBaseFolder(string patrh) {
-      return patrh.Remove(0, Setting.BaseFolder.Length).TrimStart(Path.DirectorySeparatorChar, '/');
+    internal string RemoveBaseFolder(string path) {
+      return path.Remove(0, Setting.GetBaseFolder(path).Length).TrimStart(Path.DirectorySeparatorChar, '/');
     }
 
     private string GetOutFileAbsolutePath(string inFilePath, string output_, out string module) {

--- a/CSharp.lua/LuaSyntaxGenerator.cs
+++ b/CSharp.lua/LuaSyntaxGenerator.cs
@@ -114,7 +114,7 @@ namespace CSharpLua {
 
       public void AddBaseFolder(string path, bool overwriteSubFolders) {
         var remove = new List<string>();
-        path = path.TrimEnd(Path.DirectorySeparatorChar);
+        path = new FileInfo(path).FullName.TrimEnd(Path.DirectorySeparatorChar);
         static bool ConflictsWith(string folder, string other) {
           return folder == other || folder.StartsWith(other + Path.DirectorySeparatorChar);
         }
@@ -140,7 +140,8 @@ namespace CSharpLua {
         BaseFolders.Add(path);
       }
 
-      public string GetBaseFolder(string path) {
+      public string GetBaseFolder(ref string path) {
+        path = new FileInfo(path).FullName;
         foreach (var baseFolder in BaseFolders) {
           if (path.StartsWith(baseFolder + Path.DirectorySeparatorChar)) {
             return baseFolder;
@@ -319,7 +320,8 @@ namespace CSharpLua {
     }
 
     internal string RemoveBaseFolder(string path) {
-      return path.Remove(0, Setting.GetBaseFolder(path).Length).TrimStart(Path.DirectorySeparatorChar, '/');
+      var baseFolder = Setting.GetBaseFolder(ref path);
+      return path.Remove(0, baseFolder.Length).TrimStart(Path.DirectorySeparatorChar, '/');
     }
 
     private string GetOutFileAbsolutePath(string inFilePath, string output_, out string module) {

--- a/CSharp.lua/LuaSyntaxGenerator.cs
+++ b/CSharp.lua/LuaSyntaxGenerator.cs
@@ -57,7 +57,10 @@ namespace CSharpLua {
       public string IndentString { get; private set; }
       public bool IsClassic { get; set; }
       public bool IsExportMetadata { get; set; }
-      public string BaseFolder { get; set; } = "";
+      public string BaseFolder {
+        get => BaseFolders.SingleOrDefault() ?? string.Empty;
+        set { BaseFolders.Clear(); BaseFolders.Add(value); } }
+      internal HashSet<string> BaseFolders { get; private set; }
       public bool IsExportAttributesAll { get; private set; }
       public bool IsExportEnumAll { get; private set; }
       public bool IsModule { get; set; }
@@ -69,6 +72,7 @@ namespace CSharpLua {
 
       public SettingInfo() {
         Indent = 2;
+        BaseFolders = new HashSet<string>();
       }
 
       public string[] Attributes {
@@ -105,6 +109,32 @@ namespace CSharpLua {
             IndentString = new string(' ', indent_);
           }
         }
+      }
+
+      public bool AddBaseFolder(string path) {
+        var remove = new List<string>();
+        foreach (var other in BaseFolders) {
+          if (path.StartsWith(other)) {
+            return false;
+          }
+          if (other.StartsWith(path)) {
+            remove.Add(other);
+          }
+        }
+        foreach (var other in remove) {
+          BaseFolders.Remove(other);
+        }
+        BaseFolders.Add(path);
+        return true;
+      }
+
+      public string GetBaseFolder(string path) {
+        foreach (var baseFolder in BaseFolders) {
+          if (path.StartsWith(baseFolder)) {
+            return baseFolder;
+          }
+        }
+        throw new DirectoryNotFoundException($"Could not find base folder for path: \"{path}\".");
       }
     }
 

--- a/CSharp.lua/LuaSyntaxGenerator.cs
+++ b/CSharp.lua/LuaSyntaxGenerator.cs
@@ -112,7 +112,26 @@ namespace CSharpLua {
         }
       }
 
-      public bool AddBaseFolder(string path) {
+      public void AddBaseFolder(string path, bool overwriteSubFolders) {
+        var remove = new List<string>();
+        foreach (var other in BaseFolders) {
+          if (path.StartsWith(other)) {
+            throw new Exception();
+          }
+          if (other.StartsWith(path)) {
+            if (!overwriteSubFolders) {
+              throw new Exception();
+            }
+            remove.Add(other);
+          }
+        }
+        foreach (var other in remove) {
+          BaseFolders.Remove(other);
+        }
+        BaseFolders.Add(path);
+      }
+
+      public bool TryAddBaseFolder(string path) {
         var remove = new List<string>();
         foreach (var other in BaseFolders) {
           if (path.StartsWith(other)) {

--- a/CSharp.lua/PackageHelper.cs
+++ b/CSharp.lua/PackageHelper.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace CSharp.lua {
+  public sealed class PackageException : Exception {
+    public PackageException() {
+    }
+    public PackageException(string message) : base(message) {
+    }
+  }
+
+  internal sealed class VersionStatus {
+    public VersionRange Allowed { get; private set; }
+    public NuGetVersion Selected { get; private set; }
+    public VersionStatus(VersionRange versionRange) {
+      Allowed = versionRange;
+    }
+    public bool SelectBestMatch(string id) {
+      if (Selected is null) {
+        Selected = Allowed.FindBestMatch(PackageHelper.GetAvailableVersions(id));
+        return true;
+      } else {
+        return false;
+      }
+    }
+    public void UpdateAllowedRange(VersionRange range) {
+      Allowed = VersionRange.Combine(new[] { Allowed, range });
+    }
+  }
+
+  internal static class PackageHelper {
+    private static readonly string _globalPackagesPath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetHome), SettingsUtility.DefaultGlobalPackagesFolderPath);
+
+    internal static IEnumerable<NuGetVersion> GetAvailableVersions(string packageName) {
+      var packagePath = Path.Combine(_globalPackagesPath, packageName);
+      // TODO: run package restore (always or only when directory doesn't exist?)
+      if (!Directory.Exists(packagePath)) {
+        yield break;
+      }
+      foreach (var packageVersionPath in Directory.EnumerateDirectories(packagePath)) {
+        yield return NuGetVersion.Parse(new DirectoryInfo(packageVersionPath).Name);
+      }
+    }
+
+    public static IEnumerable<string> EnumeratePackages(string targetFrameworkVersion, IEnumerable<Cake.Incubator.Project.CustomProjectParserResult> projects) {
+      // TODO: check if this cast is correct
+      var targetFramework = NuGetFramework.ParseFrameworkName(targetFrameworkVersion, DefaultFrameworkNameProvider.Instance);
+      var packages = new Dictionary<string, VersionStatus>();
+      void AddPackageReference(string id, VersionRange versionRange) {
+        if (packages.TryGetValue(id, out var versionStatus)) {
+          if (versionStatus.Selected is null) {
+            versionStatus.UpdateAllowedRange(versionRange);
+          } else if (!versionRange.Satisfies(versionStatus.Selected)) {
+            throw new PackageException($"Incompatible package dependency for package {id} {versionStatus.Selected}: {versionRange}");
+          }
+        } else {
+          packages.Add(id, new VersionStatus(versionRange));
+        }
+      }
+      foreach (var package in projects.SelectMany(project => project.PackageReferences)) {
+        AddPackageReference(package.Name, VersionRange.Parse(package.Version));
+      }
+      var newDependencies = new HashSet<PackageIdentity>();
+      while (true) {
+        foreach (var package in packages) {
+          if (package.Value.SelectBestMatch(package.Key)) {
+            newDependencies.Add(new PackageIdentity(package.Key, package.Value.Selected));
+          }
+        }
+        if (newDependencies.Count == 0) {
+          break;
+        }
+        foreach (var package in newDependencies.SelectMany(package => GetDependencies(package, targetFramework))) {
+          AddPackageReference(package.Id, package.VersionRange);
+        }
+        newDependencies.Clear();
+      }
+      foreach (var package in packages) {
+        yield return Path.Combine(_globalPackagesPath, package.Key, package.Value.Selected.ToNormalizedString());
+      }
+    }
+
+    private static IEnumerable<PackageDependency> GetDependencies(PackageIdentity package, NuGetFramework targetFramework) {
+      var nuspecFile = Path.Combine(_globalPackagesPath, package.Id, package.Version.ToNormalizedString(), $"{package.Id}.nuspec");
+      if (!NuGet.Packaging.PackageHelper.IsNuspec(nuspecFile)) {
+        throw new PackageException($"Could not locate the .nuspec file for package: {package}");
+      }
+      var reader = new NuspecReader(nuspecFile);
+      var compatibleGroups = reader.GetDependencyGroups().Where(dependencyGroup => NuGetFrameworkUtility.IsCompatibleWithFallbackCheck(targetFramework, dependencyGroup.TargetFramework));
+      // TODO: how to select best match dependencyGroup?
+      return compatibleGroups.First().Packages;
+    }
+  }
+}

--- a/CSharp.lua/PackageHelper.cs
+++ b/CSharp.lua/PackageHelper.cs
@@ -58,21 +58,22 @@ namespace CSharpLua {
       }
     }
 
-    public static IEnumerable<string> EnumerateSourceFiles((string packagePath, string frameworkFolderName) package) {
+    public static IEnumerable<string> EnumerateSourceFiles((string packagePath, string frameworkFolderName) package, out string baseFolder) {
       var sourcesPath = Path.Combine(package.packagePath, "contentFiles", "cs");
-      return EnumerateFiles(sourcesPath, package.frameworkFolderName, "*.cs", SearchOption.AllDirectories);
+      return EnumerateFiles(sourcesPath, package.frameworkFolderName, "*.cs", SearchOption.AllDirectories, out baseFolder);
     }
 
     public static IEnumerable<string> EnumerateLibs((string packagePath, string frameworkFolderName) package) {
       var libPath = Path.Combine(package.packagePath, "lib");
-      return EnumerateFiles(libPath, package.frameworkFolderName, "*.dll", SearchOption.TopDirectoryOnly);
+      return EnumerateFiles(libPath, package.frameworkFolderName, "*.dll", SearchOption.TopDirectoryOnly, out _);
     }
 
-    private static IEnumerable<string> EnumerateFiles(string path, string frameworkFolderName, string searchPattern, SearchOption searchOption) {
+    private static IEnumerable<string> EnumerateFiles(string path, string frameworkFolderName, string searchPattern, SearchOption searchOption, out string frameworkPath) {
       if (!Directory.Exists(path)) {
+        frameworkPath = null;
         return Array.Empty<string>();
       }
-      var frameworkPath = Path.Combine(path, frameworkFolderName ?? Directory.EnumerateDirectories(path).Single());
+      frameworkPath = Path.Combine(path, frameworkFolderName ?? Directory.EnumerateDirectories(path).Single());
       if (!Directory.Exists(frameworkPath)) {
         var targetFramework = NuGetFramework.Parse(frameworkFolderName);
         var compatibleFrameworks = Directory.EnumerateDirectories(path)

--- a/CSharp.lua/PackageHelper.cs
+++ b/CSharp.lua/PackageHelper.cs
@@ -37,7 +37,7 @@ namespace CSharpLua {
       }
     }
     public void UpdateAllowedRange(VersionRange range) {
-      Allowed = VersionRange.Combine(new[] { Allowed, range });
+      Allowed = VersionRange.CommonSubSet(new[] { Allowed, range });
     }
     public override string ToString() {
       return Selected?.ToString() ?? Allowed.ToString();

--- a/CSharp.lua/PackageHelper.cs
+++ b/CSharp.lua/PackageHelper.cs
@@ -58,15 +58,15 @@ namespace CSharpLua {
       }
     }
 
-    public static IEnumerable<string> EnumerateLibs(string packagePath, string frameworkFolderName) {
+    public static IEnumerable<string> EnumerateLibs((string packagePath, string frameworkFolderName) package) {
       const string SearchPattern = "*.dll";
-      var libPath = Path.Combine(packagePath, "lib");
+      var libPath = Path.Combine(package.packagePath, "lib");
       if (!Directory.Exists(libPath)) {
         return Array.Empty<string>();
       }
-      var frameworkPath = Path.Combine(libPath, frameworkFolderName ?? Directory.EnumerateDirectories(libPath).Single());
+      var frameworkPath = Path.Combine(libPath, package.frameworkFolderName ?? Directory.EnumerateDirectories(libPath).Single());
       if (!Directory.Exists(frameworkPath)) {
-        var targetFramework = NuGetFramework.Parse(frameworkFolderName);
+        var targetFramework = NuGetFramework.Parse(package.frameworkFolderName);
         var compatibleFrameworks = Directory.EnumerateDirectories(libPath)
           .Where(folder => NuGetFrameworkUtility.IsCompatibleWithFallbackCheck(targetFramework, NuGetFramework.ParseFolder(new DirectoryInfo(folder).Name)));
         // TODO: how to select best match framework?

--- a/CSharp.lua/PackageHelper.cs
+++ b/CSharp.lua/PackageHelper.cs
@@ -59,6 +59,7 @@ namespace CSharpLua {
     }
 
     public static IEnumerable<string> EnumerateLibs(string packagePath, string frameworkFolderName) {
+      const string SearchPattern = "*.dll";
       var libPath = Path.Combine(packagePath, "lib");
       if (!Directory.Exists(libPath)) {
         return Array.Empty<string>();
@@ -74,12 +75,12 @@ namespace CSharpLua {
           // Ignore folders that contain no .dll files (these usually have a file called "_._" in it).
           compatibleFrameworks = Directory.EnumerateDirectories(libPath)
           .Where(folder => NuGetFrameworkUtility.IsCompatibleWithFallbackCheck(NuGetFramework.ParseFolder(new DirectoryInfo(folder).Name), targetFramework))
-          .Where(folder => Directory.EnumerateFiles(folder, "*.dll", SearchOption.AllDirectories).FirstOrDefault() != null);
+          .Where(folder => Directory.EnumerateFiles(folder, SearchPattern, SearchOption.AllDirectories).FirstOrDefault() != null);
           // TODO: how to select best match framework?
           frameworkPath = compatibleFrameworks.First();
         }
       }
-      return Directory.EnumerateFiles(frameworkPath, "*.dll", SearchOption.AllDirectories);
+      return Directory.EnumerateFiles(frameworkPath, SearchPattern, SearchOption.TopDirectoryOnly);
     }
 
     public static IEnumerable<(string folder, string frameworkFolderName)> EnumeratePackages(string targetFrameworkVersion, IEnumerable<Cake.Incubator.Project.CustomProjectParserResult> projects) {

--- a/CSharp.lua/PackageHelper.cs
+++ b/CSharp.lua/PackageHelper.cs
@@ -10,7 +10,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
-namespace CSharp.lua {
+namespace CSharpLua {
   public sealed class PackageException : Exception {
     public PackageException() {
     }

--- a/CSharp.lua/ProjectHelper.cs
+++ b/CSharp.lua/ProjectHelper.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Incubator.Project;
+
+namespace CSharpLua {
+  internal static class ProjectHelper {
+    private static readonly ICakeEnvironment _environment;
+    private static readonly IFileSystem _fileSystem;
+
+    static ProjectHelper() {
+      var platform = new CakePlatform();
+      var runtime = new CakeRuntime();
+      var cakeConsole = new CakeConsole();
+      var cakeLog = new CakeBuildLog(cakeConsole, Verbosity.Quiet);
+
+      _environment = new CakeEnvironment(platform, runtime, cakeLog);
+      _fileSystem = new FileSystem();
+    }
+
+    public static CustomProjectParserResult ParseProject(string path, string configuration, string platform = "AnyCPU") {
+      return ParseProject(new FilePath(path), Environment.CurrentDirectory, configuration, platform);
+    }
+
+    private static CustomProjectParserResult ParseProject(FilePath path, string workingDirectory, string configuration, string platform) {
+      if (path.IsRelative) {
+        _environment.WorkingDirectory = workingDirectory;
+        path = path.MakeAbsolute(_environment);
+      }
+
+      return _fileSystem.GetFile(path).ParseProjectFile(configuration, platform);
+    }
+
+    public static IEnumerable<(string path, CustomProjectParserResult project)> EnumerateProjects(this CustomProjectParserResult mainProject) {
+      var result = new Dictionary<string, CustomProjectParserResult>();
+      void AddReferences(string folderPath, CustomProjectParserResult project) {
+        foreach (var referencedProject in project.ProjectReferences.Select(p => ParseProject(p.FilePath, folderPath, project.Configuration, project.Platform))) {
+          var directory = referencedProject.GetDirectory();
+          if (result.TryAdd(directory, referencedProject)) {
+            AddReferences(directory, referencedProject);
+          } else if (referencedProject.ProjectFilePath != result[directory].ProjectFilePath) {
+            throw new Exception("Found two or more projects in the same directory.");
+          }
+        }
+      }
+      var mainDirectory = mainProject.GetDirectory();
+      result.Add(mainDirectory, mainProject);
+      AddReferences(mainDirectory, mainProject);
+      return (IEnumerable<(string path, CustomProjectParserResult project)>)result;
+    }
+
+    public static string GetDirectory(this CustomProjectParserResult project) {
+      return project.ProjectFilePath.GetDirectory().FullPath;
+    }
+  }
+}

--- a/CSharp.lua/ProjectHelper.cs
+++ b/CSharp.lua/ProjectHelper.cs
@@ -35,7 +35,7 @@ namespace CSharpLua {
       return _fileSystem.GetFile(path).ParseProjectFile(configuration, platform);
     }
 
-    public static IEnumerable<(string path, CustomProjectParserResult project)> EnumerateProjects(this CustomProjectParserResult mainProject) {
+    public static IEnumerable<(string folder, CustomProjectParserResult project)> EnumerateProjects(this CustomProjectParserResult mainProject) {
       var result = new Dictionary<string, CustomProjectParserResult>();
       void AddReferences(string folderPath, CustomProjectParserResult project) {
         foreach (var referencedProject in project.ProjectReferences.Select(p => ParseProject(p.FilePath, folderPath, project.Configuration, project.Platform))) {

--- a/CSharp.lua/ProjectHelper.cs
+++ b/CSharp.lua/ProjectHelper.cs
@@ -50,7 +50,9 @@ namespace CSharpLua {
       var mainDirectory = mainProject.GetDirectory();
       result.Add(mainDirectory, mainProject);
       AddReferences(mainDirectory, mainProject);
-      return (IEnumerable<(string path, CustomProjectParserResult project)>)result;
+      foreach (var pair in result) {
+        yield return (pair.Key, pair.Value);
+      }
     }
 
     public static string GetDirectory(this CustomProjectParserResult project) {

--- a/CSharp.lua/ProjectHelper.cs
+++ b/CSharp.lua/ProjectHelper.cs
@@ -58,5 +58,25 @@ namespace CSharpLua {
     public static string GetDirectory(this CustomProjectParserResult project) {
       return project.ProjectFilePath.GetDirectory().FullPath;
     }
+
+    public static IEnumerable<string> EnumerateSourceFiles(this CustomProjectParserResult project, string folder = null) {
+      folder ??= project.GetDirectory();
+      const string ObjFolder = "obj";
+      const string OutputFolder = "bin";
+      const string SearchPattern = "*.cs";
+      foreach (var file in System.IO.Directory.EnumerateFiles(folder, SearchPattern, System.IO.SearchOption.TopDirectoryOnly)) {
+        yield return file;
+      }
+      var ignoredSubFolders = new HashSet<string>() { ObjFolder, OutputFolder };
+      foreach (var subFolder in System.IO.Directory.EnumerateDirectories(folder)) {
+        var subFolderName = new System.IO.DirectoryInfo(subFolder).Name;
+        if (ignoredSubFolders.Contains(subFolderName)) {
+          continue;
+        }
+        foreach (var file in System.IO.Directory.EnumerateFiles(subFolder, SearchPattern, System.IO.SearchOption.AllDirectories)) {
+          yield return file;
+        }
+      }
+    }
   }
 }

--- a/test/self-compiling/self.bat
+++ b/test/self-compiling/self.bat
@@ -2,6 +2,6 @@ set dir=bin/Release/PublishOutput/
 dotnet publish ../../ --configuration Release --output %dir%
 set obj="../../CSharp.lua/obj"
 if exist %obj% rd /s /q %obj%
-dotnet "%dir%CSharp.lua.Launcher.dll" -s ../../CSharp.lua/ -d selfout -l %dir%Microsoft.CodeAnalysis.CSharp.dll;%dir%Microsoft.CodeAnalysis.dll;%dir%Cake.Common.dll;%dir%Cake.Core.dll;%dir%Cake.Incubator.dll -metadata
+dotnet "%dir%CSharp.lua.Launcher.dll" -s ../../CSharp.lua/ -d selfout -l %dir%Microsoft.CodeAnalysis.CSharp.dll;%dir%Microsoft.CodeAnalysis.dll;%dir%Cake.Common.dll;%dir%Cake.Core.dll;%dir%Cake.Incubator.dll;%dir%NuGet.Common.dll;%dir%NuGet.Configuration.dll;%dir%NuGet.Frameworks.dll;%dir%NuGet.Packaging.dll;%dir%NuGet.Versioning.dll;%dir%Newtonsoft.Json.dll -metadata
 rd /s /q bin
 pause

--- a/test/self-compiling/self.bat
+++ b/test/self-compiling/self.bat
@@ -2,6 +2,6 @@ set dir=bin/Release/PublishOutput/
 dotnet publish ../../ --configuration Release --output %dir%
 set obj="../../CSharp.lua/obj"
 if exist %obj% rd /s /q %obj%
-dotnet "%dir%CSharp.lua.Launcher.dll" -s ../../CSharp.lua/ -d selfout -l %dir%Microsoft.CodeAnalysis.CSharp.dll;%dir%Microsoft.CodeAnalysis.dll -metadata
+dotnet "%dir%CSharp.lua.Launcher.dll" -s ../../CSharp.lua/ -d selfout -l %dir%Microsoft.CodeAnalysis.CSharp.dll;%dir%Microsoft.CodeAnalysis.dll;%dir%Cake.Common.dll;%dir%Cake.Core.dll;%dir%Cake.Incubator.dll -metadata
 rd /s /q bin
 pause


### PR DESCRIPTION
As requested in #17
This uses the Cake packages to read a .csproj file and obtain its project- and packagereferences.
The way this enumerates over .cs files could still be improved. It currently assumes that all .cs files (except the ones in bin and obj) are compiled.
It also reads packages using NuGet.Packaging. This allows it to enumerate over .dll files, so you do not have to manually add them with the libs argument.