### PR TITLE
Fix inconsistency of name sorting in lua and C#.

### DIFF
--- a/CSharp.lua/LuaAst/LuaTypeDeclarationSyntax.cs
+++ b/CSharp.lua/LuaAst/LuaTypeDeclarationSyntax.cs
@@ -530,7 +530,7 @@ namespace CSharpLua.LuaAst {
 
     private static void SortMetaData(LuaTableExpression metaData) {
       if (metaData != null) {
-        metaData.Items.Sort((x, y) => Utility.CompareStrings(MetaDataName(x), MetaDataName(y)));
+        metaData.Items.Sort((x, y) => string.Compare(MetaDataName(x), MetaDataName(y), StringComparison.Ordinal));
       }
     }
 

--- a/CSharp.lua/LuaAst/LuaTypeDeclarationSyntax.cs
+++ b/CSharp.lua/LuaAst/LuaTypeDeclarationSyntax.cs
@@ -530,7 +530,7 @@ namespace CSharpLua.LuaAst {
 
     private static void SortMetaData(LuaTableExpression metaData) {
       if (metaData != null) {
-        metaData.Items.Sort((x, y) => MetaDataName(x).CompareTo(MetaDataName(y)));
+        metaData.Items.Sort((x, y) => Utility.CompareStrings(MetaDataName(x), MetaDataName(y)));
       }
     }
 

--- a/CSharp.lua/Utils.cs
+++ b/CSharp.lua/Utils.cs
@@ -1332,24 +1332,6 @@ namespace CSharpLua {
       return node.Accept<LuaExpressionSyntax>(transform);
     }
 
-    public static int CompareStrings(string x, string y) {
-
-      for (var i = 0; i < x.Length && i < y.Length; i++) {
-        var cmp = ((int)x[i]).CompareTo(y[i]);
-        if (cmp != 0) {
-          return cmp;
-        }
-      }
-
-      if (x.Length > y.Length) {
-        return 1;
-      } else if (x.Length == y.Length) {
-        return 0;
-      } else {
-        return -1;
-      }
-    }
-
 #region hard code for protobuf-net
 
     public static bool IsProtobufNetDeclaration(this INamedTypeSymbol type) {

--- a/CSharp.lua/Utils.cs
+++ b/CSharp.lua/Utils.cs
@@ -1332,6 +1332,24 @@ namespace CSharpLua {
       return node.Accept<LuaExpressionSyntax>(transform);
     }
 
+    public static int CompareStrings(string x, string y) {
+
+      for (var i = 0; i < x.Length && i < y.Length; i++) {
+        var cmp = ((int)x[i]).CompareTo(y[i]);
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+
+      if (x.Length > y.Length) {
+        return 1;
+      } else if (x.Length == y.Length) {
+        return 0;
+      } else {
+        return -1;
+      }
+    }
+
 #region hard code for protobuf-net
 
     public static bool IsProtobufNetDeclaration(this INamedTypeSymbol type) {


### PR DESCRIPTION
So I ran into this bug while trying to find another bug that I later found out wasn't a bug. Neat.

So this problem is an inconsistency in the way that C# and Lua sort strings, specifically case sensitivity. Lua sorts based on their ASCII codes, while C# sorts based on alphabetic order.

So C# would generate:
```
abcName
ZZZName
```
while lua expects:
```
ZZZName
abcName
```
This then causes issues in the binarySearchByName lua function, as the table is not properly sorted.