### PR TITLE
Fix GetGenericArguments for more than 1 generic type

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
@@ -893,15 +893,16 @@ function Type.GetGenericArguments(this)
   local name = cls.__name__ 
   local i = name:find("%[")
   if i then
+    i = i + 1
     while true do
-      i = i + 1
       local j = name:find(",", i) or -1
       local clsName = name:sub(i, j - 1)
       t[count] = typeof(System.getClass(clsName))
-      count = count + 1
       if j == -1 then
         break
       end
+      count = count + 1
+      i = j + 1
     end
   end
   return arrayFromTable(t, Type)


### PR DESCRIPTION
The start index of the substring wasn't being adjusted to account for the length of the previously matched string.

See example:

```
using System;
using System.Reflection;
using System.Collections.Generic;

namespace LuaTest {
  internal class Program {
	private static void Main(string[] args)
	{
		var dict = new Dictionary<int, string>();
		var types = dict.GetType().GetGenericArguments();
		Console.WriteLine(types[0].Name);
		Console.WriteLine(types[1].Name);
	}
  }
}
```

Here, clsName will be `System.Int32` for the first type (correct), and `ystem.Int32` for the second type (incorrect).