### PR TITLE
Add IsArray and GetElementType implementations.

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Type.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Type.lua
@@ -161,6 +161,10 @@ local function isGenericTypeDefinition(this)
   return getGenericClass(cls) == cls
 end
 
+local function getIsArray(this)
+  return this[1].__name__:byte(-2) == 91
+end
+
 Type = System.define("System.Type", {
   Equals = System.equals,
   getIsGenericType = function (this)
@@ -243,6 +247,13 @@ Type = System.define("System.Type", {
       return false 
     end
     return isAssignableFrom(this, obj:GetType())
+  end,
+  getIsArray = getIsArray,
+  GetElementType = function (this)
+    if getIsArray(this) then
+      return typeof(this[1].__genericT__)
+    end
+    return nil
   end,
   ToString = function (this)
     return this[1].__name__


### PR DESCRIPTION
Probably my last bit of Reflection that I'd like to have access to.
GetElementType is pretty self-explanatory, and as for getIsArray, it checks if the second to last character is `[`. If it is, that means it must end on `[]`, meaning it's an array.

I didn't see a better way of figuring out if something is an array for sure, as e.g. `isArrayLike` is also true for lists. And unless I'm mistaken, I do not believe it is possible for non-array types to end with `[]`, as e.g. unspecified generic types will follow the pattern of ``System.Collections.Generic.List`1``.

Confirmed to work correctly on the below test case:
```csharp
using System;
using System.Reflection;
using System.Collections.Generic;

namespace LuaTest {
  public class Program {
	private static void Main(string[] args)
	{
		var a = new int[5];
		var b = new int[5][];
		Console.WriteLine(a.GetType().IsArray); // true
		Console.WriteLine(b.GetType().IsArray); // true
		Console.WriteLine(typeof(int[]).IsArray); // true
		Console.WriteLine(typeof(int[][]).IsArray); // true
		Console.WriteLine(typeof(List<int>[]).IsArray); // true
		Console.WriteLine(typeof(List<int[]>).IsArray); // false
		Console.WriteLine(typeof(List<int>).IsArray); // false
		Console.WriteLine(typeof(Program).IsArray); // false
	}
  }
}
```