### PR TITLE
Move generic using declerations to initStatements.

### DIFF
--- a/CSharp.lua/LuaAst/LuaTypeDeclarationSyntax.cs
+++ b/CSharp.lua/LuaAst/LuaTypeDeclarationSyntax.cs
@@ -598,7 +598,8 @@ namespace CSharpLua.LuaAst {
       if (genericUsingDeclares_.Count > 0) {
         genericUsingDeclares_.Sort();
         foreach (var import in genericUsingDeclares_) {
-          body.AddStatement(new LuaLocalVariableDeclaratorSyntax(import.NewName, import.InvocationExpression));
+          initStatements_.Insert(0, new LuaAssignmentExpressionSyntax(import.NewName, import.InvocationExpression));
+          local_.Variables.Add(import.NewName);
         }
       }
     }


### PR DESCRIPTION
Did some more investigation and finally figured out where I had to be. This seems to address https://github.com/yanghuan/CSharp.lua/issues/351.

This changes the definition from:
```lua
  namespace.class("BaseClass_1", function (namespace)
    return function (T)
      local __ctor__
      local Test_1T = LuaTest.Test_1(T)
      __ctor__ = function (this)
        this.Property = Test_1T()
      end
      return {
        __ctor__ = __ctor__,
        __metadata__ = function (out)
          return {
            properties = {
              { "Property", 0x6, out.LuaTest.Test_1(T) }
            },
            class = { 0x106, T }
          }
        end
      }
    end
  end)
```
to
```lua
  namespace.class("BaseClass_1", function (namespace)
    return function (T)
      local Test_1T, __ctor__
      __ctor__ = function (this)
        Test_1T = LuaTest.Test_1(T)
        this.Property = Test_1T()
      end
      return {
        __ctor__ = __ctor__,
        __metadata__ = function (out)
          return {
            properties = {
              { "Property", 0x6, out.LuaTest.Test_1(T) }
            },
            class = { 0x106, T }
          }
        end
      }
    end
  end)
```

Unless there is a special purpose for generic definitions to be performed immediately rather than in the constructor, I do not see an issue with this solution.