### PR TITLE
Fix test encoding and base.property issue

### DIFF
--- a/CSharp.lua/LuaSyntaxNodeTransform.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.cs
@@ -2591,11 +2591,17 @@ namespace CSharpLua {
           if (nameExpression is LuaPropertyAdapterExpressionSyntax propertyMethod) {
             if (baseExpression != LuaIdentifierNameSyntax.This) {
               propertyMethod.ArgumentList.AddArgument(LuaIdentifierNameSyntax.This);
+              propertyMethod.Update(baseExpression, false);
+            } else {
+              propertyMethod.Update(baseExpression, true);
             }
-            propertyMethod.Update(baseExpression, false);
             return propertyMethod;
           } else {
-            return baseExpression.MemberAccess(nameExpression);
+            if (nameExpression is LuaMemberAccessExpressionSyntax memberAccess && memberAccess.Expression == LuaIdentifierNameSyntax.This) {
+              return nameExpression;
+            } else {
+              return baseExpression.MemberAccess(nameExpression);
+            }
           }
         } else {
           if (baseExpression == LuaIdentifierNameSyntax.This) {

--- a/test/BridgeNetTests/Batch1/src/PropertyAccessorTests.cs
+++ b/test/BridgeNetTests/Batch1/src/PropertyAccessorTests.cs
@@ -261,6 +261,62 @@ namespace Bridge.ClientTest
                 }
             }
         }
+		
+		public class B5
+		{
+			public int F1, F2, F3;
+
+            public int P1
+            {
+                get
+                {
+                    return F1;
+                }
+                set
+                {
+                    F1 = value;
+                }
+            }
+
+            public int P2
+            {
+                get
+                {
+                    return F2;
+                }
+            }
+
+            public int P3
+            {
+                set
+                {
+                    F3 = value;
+                }
+            }
+		}
+		
+		public class D5 : B5
+		{
+			public int GetP1()
+			{
+				return base.P1 + 1;
+			}
+			
+			public void SetP1(int value)
+			{
+				base.P1 = value - 1;
+			}
+			
+			public int GetP2()
+			{
+				return base.P2 + 1;
+			}
+			
+			public void SetP3(int value)
+			{
+				base.P3 = value - 1;
+			}
+		}
 
 #pragma warning restore 649
 
@@ -333,7 +389,7 @@ namespace Bridge.ClientTest
         }
 
         [Test]
-        public void BaseAccessorsCanBeInvoked()
+        public void BaseAccessorsCanBeInvokedOverride()
         {
             var d = new D3();
 
@@ -365,6 +421,24 @@ namespace Bridge.ClientTest
             Assert.AreEqual(18, d.P2, "P2 value");
 
             d.P3 = 12;
+            Assert.AreEqual(11, d.F3, "F3 value");
+        }
+
+        [Test]
+        public void BaseAccessorsCanBeInvoked()
+        {
+            var d = new D5();
+			
+			d.SetP1(42);
+            Assert.AreEqual(41, d.F1, "F1 value");
+
+            d.F1 = 15;
+            Assert.AreEqual(16, d.GetP1(), "P1 value");
+
+            d.F2 = 17;
+            Assert.AreEqual(18, d.GetP2(), "P2 value");
+
+            d.SetP3(12);
             Assert.AreEqual(11, d.F3, "F3 value");
         }
     }

--- a/test/TestCases/src/Tests/TestValueTypeBinding.cs
+++ b/test/TestCases/src/Tests/TestValueTypeBinding.cs
@@ -1,4 +1,4 @@
-using System;
+ï»¿using System;
 using ILRuntimeTest.TestFramework;
 
 namespace TestCases
@@ -185,7 +185,7 @@ namespace TestCases
         public static void UnitTest_10030()
         {
         #if COMPILE_BUG
-            vecCls.Vector2 += TestVector3.One2 * (0.456f - vecCls.Vector2.Y * 2);//ÕâÑù»áÓÐ
+            vecCls.Vector2 += TestVector3.One2 * (0.456f - vecCls.Vector2.Y * 2);//è¿™æ ·ä¼šæœ‰
 
             Console.WriteLine(vecCls.Vector2);
 #endif
@@ -195,12 +195,12 @@ namespace TestCases
         {
             TestVector3 pos = TestVector3.One2;
             float offsetX = pos.X - 0.1f;
-            float offsetY = pos.Y - 0.1f;//±¨´íÐÐÊýÔÚÕâÀï
+            float offsetY = pos.Y - 0.1f;//æŠ¥é”™è¡Œæ•°åœ¨è¿™é‡Œ
             if (offsetX > 1)
                 Console.WriteLine("1");
             else if (offsetX < -1)
                 Console.WriteLine("2");
-            //×¢ÊÍÏÂÃæµÄ´úÂë¾Í²»»á³ö´íÁË
+            //æ³¨é‡Šä¸‹é¢çš„ä»£ç å°±ä¸ä¼šå‡ºé”™äº†
             else if (offsetY > 1)
                 Console.WriteLine("3");
             else if (offsetY < -1)


### PR DESCRIPTION
Batching these two together since the first was preventing me from setting up a test case...

First issue is a simple encoding error. On my locale this turned into something like `//��������������` which would also result in it eating a newline, causing compilation to fail. I didn't see any other cases where GB2312 was used.

For the second issue, a non-override `base.Property` would cause it to produce `this.getP1()` instead of `this:getP1()`.  
Additionally, with -inline-property enabled it would generate `this.this.F2 = value`, so I added a check to not add it if it's already included.
These issues didn't appear with override properties, so I renamed the existing test that explicitly had override properties.