### PR TITLE
Fix nullable properties placing object name wrong

### DIFF
--- a/CSharp.lua/LuaSyntaxNodeTransform.Helper.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.Helper.cs
@@ -1089,6 +1089,14 @@ namespace CSharpLua {
     }
 
     private LuaExpressionSyntax BuildFieldOrPropertyMemberAccessExpression(LuaExpressionSyntax expression, LuaExpressionSyntax name, bool isStatic) {
+      if (name is LuaInvocationExpressionSyntax luaInvocation && luaInvocation.Expression == LuaIdentifierNameSyntax.NullableClone) {
+        for (var i = 0; i < luaInvocation.Arguments.Count; i++) {
+          luaInvocation.Arguments[i] = BuildFieldOrPropertyMemberAccessExpression(expression, luaInvocation.Arguments[i], isStatic);
+        }
+
+        return name;
+      }
+
       if (name is LuaPropertyAdapterExpressionSyntax propertyMethod) {
         var arguments = propertyMethod.ArgumentList.Arguments;
         if (arguments.Count == 1) {

--- a/test/BridgeNetTests/Batch1/src/NullableTests.cs
+++ b/test/BridgeNetTests/Batch1/src/NullableTests.cs
@@ -15,6 +15,14 @@ namespace Bridge.ClientTest
             return value is T;
         }
 
+        public class PropertyTest
+        {
+            public int? field;
+            public static int? fieldStatic;
+            public int? Property { get; set; }
+            public static int? PropertyStatic { get; set; }
+        }
+
 #pragma warning disable 660, 661
 
         private struct MyType
@@ -653,6 +661,58 @@ namespace Bridge.ClientTest
 
             var s2 = boxed.ToString();
             Assert.AreEqual("Value2", s2);
+        }
+
+        [Test]
+        public void NullableFieldWorks()
+        {
+            var a = new PropertyTest();
+
+            Assert.False(a.field.HasValue);
+            a.field = 5;
+            Assert.True(a.field.HasValue);
+            Assert.AreEqual(5, a.field);
+            Assert.AreEqual(5, a.field.Value);
+            a.field = null;
+            Assert.False(a.field.HasValue);
+        }
+
+        [Test]
+        public void NullableFieldStaticWorks()
+        {
+            Assert.False(PropertyTest.fieldStatic.HasValue);
+            PropertyTest.fieldStatic = 5;
+            Assert.True(PropertyTest.fieldStatic.HasValue);
+            Assert.AreEqual(5, PropertyTest.fieldStatic);
+            Assert.AreEqual(5, PropertyTest.fieldStatic.Value);
+            PropertyTest.fieldStatic = null;
+            Assert.False(PropertyTest.fieldStatic.HasValue);
+        }
+
+        [Test]
+        public void NullablePropertyWorks()
+        {
+            var a = new PropertyTest();
+
+            Assert.False(a.Property.HasValue);
+            a.Property = 5;
+            Assert.True(a.Property.HasValue);
+            Assert.AreEqual(5, a.Property);
+            Assert.AreEqual(5, a.Property.Value);
+            a.Property = null;
+            Assert.False(a.Property.HasValue);
+        }
+
+        [Test]
+        public void NullablePropertyStaticWorks()
+        {
+            Assert.False(PropertyTest.PropertyStatic.HasValue);
+            PropertyTest.PropertyStatic = 5;
+            Assert.True(PropertyTest.PropertyStatic.HasValue);
+            Assert.AreEqual(5, PropertyTest.PropertyStatic);
+            Assert.AreEqual(5, PropertyTest.PropertyStatic.Value);
+            PropertyTest.PropertyStatic = null;
+            Assert.False(PropertyTest.PropertyStatic.HasValue);
         }
     }
 }


### PR DESCRIPTION
Was working on another feature when I ran into this small mistake. This would previously generate code like `a.System.Nullable.clone(Property)`, misplacing the object name `a`.

That being said, I'm not sure if nullable properties are being handled entirely correct? They seem to be cloned almost always:

```csharp
var a = new PropertyTest();

Assert.False(a.Property.HasValue);
a.Property = 5;
Assert.True(a.Property.HasValue);
Assert.AreEqual(5, a.Property);
Assert.AreEqual(5, a.Property.Value);
a.Property = null;
Assert.False(a.Property.HasValue);
```
Turns into
```lua
local a = class.PropertyTest()

BridgeTestNUnit.Assert.False((System.Nullable.clone(a.Property) ~= nil), "")
a.Property = 5
BridgeTestNUnit.Assert.True((System.Nullable.clone(a.Property) ~= nil), "")
BridgeTestNUnit.Assert.AreEqual(5, System.Nullable.clone(a.Property))
BridgeTestNUnit.Assert.AreEqual(5, System.Nullable.Value(System.Nullable.clone(a.Property)))
a.Property = nil
BridgeTestNUnit.Assert.False((System.Nullable.clone(a.Property) ~= nil), "")
```
This does not happen with fields:
```
BridgeTestNUnit.Assert.False((a.field ~= nil), "")
a.field = 5
BridgeTestNUnit.Assert.True((a.field ~= nil), "")
BridgeTestNUnit.Assert.AreEqual(5, a.field)
BridgeTestNUnit.Assert.AreEqual(5, System.Nullable.Value(a.field))
a.field = nil
BridgeTestNUnit.Assert.False((a.field ~= nil), "")
```