### PR TITLE
Fix reflection GetMethod/GetProperty/GetField

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
@@ -566,7 +566,10 @@ local function binarySearchByName(metadata, name)
   local last = #metadata + 1
   local index = lowerBound(metadata, 1, last, name, metadataItemCompByName)
   if index ~= last then
-    return metadata[index], index
+    local item = metadata[index]
+    if (item[1] == name) then
+      return metadata[index], index
+    end
   end
   return nil
 end

--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Reflection/Assembly.lua
@@ -567,7 +567,7 @@ local function binarySearchByName(metadata, name)
   local index = lowerBound(metadata, 1, last, name, metadataItemCompByName)
   if index ~= last then
     local item = metadata[index]
-    if (item[1] == name) then
+    if item[1] == name then
       return metadata[index], index
     end
   end


### PR DESCRIPTION
`binarySearchByName` was not making sure that the lower bound was actually a match.

Example:
```
using System;
using System.Reflection;

namespace LuaTest {
  public class Program {
    private static void Main(string[] args) {
      foreach (var type in Assembly.GetExecutingAssembly().GetExportedTypes())
      {
        var method1 = type.GetMethod("Method1");
        if (method1 != null)
        {
          Console.WriteLine(method1.DeclaringType.FullName + " -> " + method1.Name);
        }
        
        var method2 = type.GetMethod("Method2");
        if (method2 != null)
        {
          Console.WriteLine(method2.DeclaringType.FullName + " -> " + method2.Name);
        }
      }
    }
  }
  
  public class Class1
  {
    public static void Method1(){}
  }
  public class Class2
  {
    public static void Method2(){}
  }
}
```

Output before:
```
LuaTest.Class1 -> Method1
LuaTest.Class2 -> Method1
LuaTest.Class2 -> Method2
```

Fixed output:
```
LuaTest.Class1 -> Method1
LuaTest.Class2 -> Method2
```