### PR TITLE
Fix an issue with rounding between -1 and -0.5.

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Math.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Math.lua
@@ -42,7 +42,7 @@ local function round(value, digits, mode)
     value = trunc(i)
     if value ~= i then
       local dif = i - value
-      if value >= 0 then
+      if i >= 0 then
         if dif > 0.5 or (dif == 0.5 and value % 2 ~= 0) then
           value = value + 1  
         end

--- a/test/BridgeNetTests/Batch1/src/MathTests.cs
+++ b/test/BridgeNetTests/Batch1/src/MathTests.cs
@@ -689,6 +689,45 @@ namespace Bridge.ClientTest
         }
 
         [Test]
+        public void RoundDoubleAround0Works()
+        {
+            NumberHelper.AssertDouble(-1, Math.Round(-0.7));
+            NumberHelper.AssertDouble(0, Math.Round(-0.5));
+            NumberHelper.AssertDouble(0, Math.Round(-0.3));
+            NumberHelper.AssertDouble(0, Math.Round(0.3));
+            NumberHelper.AssertDouble(0, Math.Round(0.5));
+            NumberHelper.AssertDouble(1, Math.Round(0.7));
+
+            NumberHelper.AssertDouble(-1, Math.Round(-0.7, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(-1, Math.Round(-0.5, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(0, Math.Round(-0.3, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(0, Math.Round(0.3, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(1, Math.Round(0.5, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(1, Math.Round(0.7, MidpointRounding.AwayFromZero));
+
+            //NumberHelper.AssertDouble(-1, Math.Round(-0.7, MidpointRounding.ToZero));
+            //NumberHelper.AssertDouble(0, Math.Round(-0.5, MidpointRounding.ToZero));
+            //NumberHelper.AssertDouble(0, Math.Round(-0.3, MidpointRounding.ToZero));
+            //NumberHelper.AssertDouble(0, Math.Round(0.3, MidpointRounding.ToZero));
+            //NumberHelper.AssertDouble(0, Math.Round(0.5, MidpointRounding.ToZero));
+            //NumberHelper.AssertDouble(1, Math.Round(0.7, MidpointRounding.ToZero));
+
+            //NumberHelper.AssertDouble(-1, Math.Round(-0.7, MidpointRounding.ToNegativeInfinity));
+            //NumberHelper.AssertDouble(-1, Math.Round(-0.5, MidpointRounding.ToNegativeInfinity));
+            //NumberHelper.AssertDouble(0, Math.Round(-0.3, MidpointRounding.ToNegativeInfinity));
+            //NumberHelper.AssertDouble(0, Math.Round(0.3, MidpointRounding.ToNegativeInfinity));
+            //NumberHelper.AssertDouble(0, Math.Round(0.5, MidpointRounding.ToNegativeInfinity));
+            //NumberHelper.AssertDouble(1, Math.Round(0.7, MidpointRounding.ToNegativeInfinity));
+
+            //NumberHelper.AssertDouble(-1, Math.Round(-0.7, MidpointRounding.ToPositiveInfinity));
+            //NumberHelper.AssertDouble(0, Math.Round(-0.5, MidpointRounding.ToPositiveInfinity));
+            //NumberHelper.AssertDouble(0, Math.Round(-0.3, MidpointRounding.ToPositiveInfinity));
+            //NumberHelper.AssertDouble(0, Math.Round(0.3, MidpointRounding.ToPositiveInfinity));
+            //NumberHelper.AssertDouble(1, Math.Round(0.5, MidpointRounding.ToPositiveInfinity));
+            //NumberHelper.AssertDouble(1, Math.Round(0.7, MidpointRounding.ToPositiveInfinity));
+        }
+
+        [Test]
         public void IEEERemainderWorks()
         {
             NumberHelper.AssertDoubleWithEpsilon8(Math.IEEERemainder(3.1, 4.0), -0.9);


### PR DESCRIPTION
`round` would truncate numbers between -1 and 0 to 0, making the check for positive/negative fail and result in the wrong rounding between -1 and -0.5.