### PR TITLE
Add support for templating properties

### DIFF
--- a/CSharp.lua/LuaAst/LuaMemberAccessExpressionSyntax.cs
+++ b/CSharp.lua/LuaAst/LuaMemberAccessExpressionSyntax.cs
@@ -117,6 +117,7 @@ namespace CSharpLua.LuaAst {
     public string GetTemplate { get; private set; }
     public string SetTemplate { get; private set; }
     public LuaCodeTemplateExpressionSyntax GetExpression { get; private set; }
+    public LuaIdentifierNameSyntax Name { get; private set; }
     public readonly LuaArgumentListSyntax ArgumentList = new();
 
     public LuaPropertyTemplateExpressionSyntax(string getExpression, string setExpression) {
@@ -124,10 +125,8 @@ namespace CSharpLua.LuaAst {
       SetTemplate = setExpression;
     }
 
-    public void Update(LuaExpressionSyntax expression, LuaCodeTemplateExpressionSyntax getExpression, bool isStatic) {
-      if (!isStatic) {
-        ArgumentList.AddArgument(expression);
-      }
+    public void Update(LuaExpressionSyntax expression, LuaCodeTemplateExpressionSyntax getExpression) {
+      Name = new LuaSymbolNameSyntax(expression);
       GetExpression = getExpression;
     }
 

--- a/CSharp.lua/LuaAst/LuaMemberAccessExpressionSyntax.cs
+++ b/CSharp.lua/LuaAst/LuaMemberAccessExpressionSyntax.cs
@@ -15,7 +15,9 @@ limitations under the License.
 */
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 
 namespace CSharpLua.LuaAst {
   public sealed class LuaMemberAccessExpressionSyntax : LuaExpressionSyntax {
@@ -108,6 +110,33 @@ namespace CSharpLua.LuaAst {
 
     internal override void Render(LuaRenderer renderer) {
       renderer.Render(this);
+    }
+  }
+
+  public sealed class LuaPropertyTemplateExpressionSyntax : LuaExpressionSyntax {
+    public string GetTemplate { get; private set; }
+    public string SetTemplate { get; private set; }
+    public LuaCodeTemplateExpressionSyntax GetExpression { get; private set; }
+    public readonly LuaArgumentListSyntax ArgumentList = new();
+
+    public LuaPropertyTemplateExpressionSyntax(string getExpression, string setExpression) {
+      GetTemplate = getExpression;
+      SetTemplate = setExpression;
+    }
+
+    public void Update(LuaExpressionSyntax expression, LuaCodeTemplateExpressionSyntax getExpression, bool isStatic) {
+      if (!isStatic) {
+        ArgumentList.AddArgument(expression);
+      }
+      GetExpression = getExpression;
+    }
+
+    internal override void Render(LuaRenderer renderer) {
+      renderer.Render(GetExpression);
+    }
+
+    internal IEnumerable<LuaExpressionSyntax> GetArguments(params LuaExpressionSyntax[] luaBinaryExpressionSyntax) {
+      return ArgumentList.Arguments.Concat(luaBinaryExpressionSyntax);
     }
   }
 }

--- a/CSharp.lua/LuaAst/LuaStatementSyntax.cs
+++ b/CSharp.lua/LuaAst/LuaStatementSyntax.cs
@@ -220,6 +220,8 @@ namespace CSharpLua.LuaAst {
       MetadataAll = 1 << 3,
       Template = 1 << 4,
       Params = 1 << 5,
+      Get = 1 << 6,
+      Set = 1 << 7
     }
 
     public readonly List<LuaStatementSyntax> Statements = new();

--- a/CSharp.lua/LuaSyntaxNodeTransform.Helper.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.Helper.cs
@@ -301,8 +301,8 @@ namespace CSharpLua {
       return InternalBuildCodeTemplateExpression(codeTemplate, null, null, null, targetExpression);
     }
 
-    private LuaExpressionSyntax BuildCodeTemplateExpression(string codeTemplate, IEnumerable<LuaExpressionSyntax> targetExpressions) {
-      return InternalBuildCodeTemplateExpression(codeTemplate, null, targetExpressions.Select<LuaExpressionSyntax, Func<LuaExpressionSyntax>>(i => () => i), null);
+    private LuaExpressionSyntax BuildCodeTemplateExpression(string codeTemplate, IEnumerable<LuaExpressionSyntax> arguments, LuaIdentifierNameSyntax memberBindingIdentifier) {
+      return InternalBuildCodeTemplateExpression(codeTemplate, null, arguments.Select<LuaExpressionSyntax, Func<LuaExpressionSyntax>>(i => () => i), null, memberBindingIdentifier);
     }
 
     private LuaExpressionSyntax BuildCodeTemplateExpression(string codeTemplate, ExpressionSyntax targetExpression, IEnumerable<LuaExpressionSyntax> arguments, IList<ITypeSymbol> typeArguments) {
@@ -1117,17 +1117,10 @@ namespace CSharpLua {
       }*/
 
       if (name is LuaPropertyTemplateExpressionSyntax propertyTemplate) {
-        if (isStatic) {
-          var getExpression = propertyTemplate.GetTemplate != null
-            ? new LuaCodeTemplateExpressionSyntax(propertyTemplate.GetTemplate)
-            : null;
-          propertyTemplate.Update(expression, getExpression, isStatic);
-        } else {
-          var getExpression = propertyTemplate.GetTemplate != null
-            ? (LuaCodeTemplateExpressionSyntax)BuildCodeTemplateExpression(propertyTemplate.GetTemplate, new[] { expression })
-            : null;
-          propertyTemplate.Update(expression, getExpression, isStatic);
-        }
+        var getExpression = propertyTemplate.GetTemplate != null
+          ? (LuaCodeTemplateExpressionSyntax)BuildCodeTemplateExpression(propertyTemplate.GetTemplate, new LuaSymbolNameSyntax(expression))
+          : null;
+        propertyTemplate.Update(expression, getExpression);
         return propertyTemplate;
       }
 

--- a/CSharp.lua/LuaSyntaxNodeTransform.Object.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.Object.cs
@@ -1243,7 +1243,7 @@ namespace CSharpLua {
       var symbol = semanticModel_.GetDeclaredSymbol(node);
       var codeTemplate = XmlMetaProvider.GetMethodCodeTemplate(symbol);
       if (codeTemplate != null) {
-        return BuildCodeTemplateExpression(codeTemplate, node.ParameterList.Accept<LuaParameterListSyntax>(this).Parameters);
+        return BuildCodeTemplateExpression(codeTemplate, node.ParameterList.Accept<LuaParameterListSyntax>(this).Parameters, null);
       }
       BuildOperatorMethodDeclaration(node);
       return base.VisitConversionOperatorDeclaration(node);

--- a/CSharp.lua/LuaSyntaxNodeTransform.Object.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.Object.cs
@@ -1240,6 +1240,11 @@ namespace CSharpLua {
     }
 
     public override LuaSyntaxNode VisitConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node) {
+      var symbol = semanticModel_.GetDeclaredSymbol(node);
+      var codeTemplate = XmlMetaProvider.GetMethodCodeTemplate(symbol);
+      if (codeTemplate != null) {
+        return BuildCodeTemplateExpression(codeTemplate, node.ParameterList.Accept<LuaParameterListSyntax>(this).Parameters);
+      }
       BuildOperatorMethodDeclaration(node);
       return base.VisitConversionOperatorDeclaration(node);
     }

--- a/CSharp.lua/LuaSyntaxNodeTransform.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.cs
@@ -900,7 +900,7 @@ namespace CSharpLua {
         bool isImmutable = typeSymbol.IsImmutable();
         foreach (var variable in node.Declaration.Variables) {
           var variableSymbol = semanticModel_.GetDeclaredSymbol(variable);
-          if (variableSymbol.IsAbstract) {
+          if (variableSymbol.IsAbstract || variableSymbol.IsExtern || variableSymbol.GetDeclaringSyntaxNode().HasCSharpLuaAttribute(LuaDocumentStatement.AttributeFlags.Ignore)) {
             continue;
           }
 
@@ -1062,7 +1062,7 @@ namespace CSharpLua {
 
     public override LuaSyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node) {
       var symbol = semanticModel_.GetDeclaredSymbol(node);
-      if (!symbol.IsAbstract) {
+      if (!symbol.IsAbstract && !symbol.IsExtern && !symbol.GetDeclaringSyntaxNode().HasCSharpLuaAttribute(LuaDocumentStatement.AttributeFlags.Ignore)) {
         bool isStatic = symbol.IsStatic;
         bool isPrivate = generator_.IsPrivate(symbol) && symbol.ExplicitInterfaceImplementations.IsEmpty;
         bool hasGet = false;
@@ -1174,7 +1174,7 @@ namespace CSharpLua {
 
     public override LuaSyntaxNode VisitEventDeclaration(EventDeclarationSyntax node) {
       var symbol = semanticModel_.GetDeclaredSymbol(node);
-      if (!symbol.IsAbstract) {
+      if (!symbol.IsAbstract && !symbol.IsExtern && !symbol.GetDeclaringSyntaxNode().HasCSharpLuaAttribute(LuaDocumentStatement.AttributeFlags.Ignore)) {
         var attributes = BuildAttributes(node.AttributeLists);
         bool isStatic = symbol.IsStatic;
         bool isPrivate = symbol.IsPrivate() && symbol.ExplicitInterfaceImplementations.IsEmpty;
@@ -1233,7 +1233,7 @@ namespace CSharpLua {
 
     public override LuaSyntaxNode VisitIndexerDeclaration(IndexerDeclarationSyntax node) {
       var symbol = semanticModel_.GetDeclaredSymbol(node);
-      if (!symbol.IsAbstract) {
+      if (!symbol.IsAbstract && !symbol.IsExtern && !symbol.GetDeclaringSyntaxNode().HasCSharpLuaAttribute(LuaDocumentStatement.AttributeFlags.Ignore)) {
         bool isPrivate = symbol.IsPrivate();
         var indexName = GetMemberName(symbol);
         var parameterList = node.ParameterList.Accept<LuaParameterListSyntax>(this);
@@ -1564,7 +1564,10 @@ namespace CSharpLua {
 
     private LuaExpressionSyntax BuildCommonAssignmentExpression(LuaExpressionSyntax left, LuaExpressionSyntax right, string operatorToken, ExpressionSyntax rightNode, ExpressionSyntax parent) {
       bool isPreventDebugConcatenation = IsPreventDebug && operatorToken == LuaSyntaxNode.Tokens.Concatenation;
-      if (left is LuaPropertyAdapterExpressionSyntax propertyAdapter) {
+      if (left is LuaPropertyTemplateExpressionSyntax propertyTemplate) {
+        var arguments = propertyTemplate.GetArguments(propertyTemplate.GetExpression.Binary(operatorToken, right));
+        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments);
+      } else if (left is LuaPropertyAdapterExpressionSyntax propertyAdapter) {
         LuaExpressionSyntax expression = null;
         var getter = propertyAdapter.GetCloneOfGet();
         LuaExpressionSyntax leftExpression = getter;
@@ -1614,6 +1617,13 @@ namespace CSharpLua {
     }
 
     private LuaExpressionSyntax BuildDelegateAssignmentExpression(LuaExpressionSyntax left, LuaExpressionSyntax right, bool isPlus) {
+      if (left is LuaPropertyTemplateExpressionSyntax propertyTemplate) {
+        var expr = isPlus
+          ? propertyTemplate.GetExpression.Plus(right)
+          : propertyTemplate.GetExpression.Sub(right);
+        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, propertyTemplate.GetArguments(expr));
+      }
+
       if (left is LuaPropertyAdapterExpressionSyntax propertyAdapter) {
         if (propertyAdapter.IsProperty) {
           propertyAdapter.ArgumentList.AddArgument(BuildDelegateBinaryExpression(propertyAdapter.GetCloneOfGet(), right, isPlus));
@@ -1629,7 +1639,11 @@ namespace CSharpLua {
     }
 
     private LuaExpressionSyntax BuildBinaryInvokeAssignmentExpression(LuaExpressionSyntax left, LuaExpressionSyntax right, LuaExpressionSyntax methodName) {
-      if (left is LuaPropertyAdapterExpressionSyntax propertyAdapter) {
+      if (left is LuaPropertyTemplateExpressionSyntax propertyTemplate) {
+        var invocation = new LuaInvocationExpressionSyntax(methodName, propertyTemplate.GetExpression, right);
+        var arguments = propertyTemplate.GetArguments(invocation);
+        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments);
+      } else if (left is LuaPropertyAdapterExpressionSyntax propertyAdapter) {
         var invocation = new LuaInvocationExpressionSyntax(methodName, propertyAdapter.GetCloneOfGet(), right);
         propertyAdapter.ArgumentList.AddArgument(invocation);
         return propertyAdapter;
@@ -1846,7 +1860,10 @@ namespace CSharpLua {
         case SyntaxKind.SimpleAssignmentExpression: {
           var left = leftNode.AcceptExpression(this);
           var right = VisitExpression(rightNode);
-          if (leftNode.Kind().IsTupleDeclaration()) {
+          if (left is LuaPropertyTemplateExpressionSyntax propertyTemplate) {
+              var arguments = propertyTemplate.GetArguments(right);
+              return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments);
+          } else if (leftNode.Kind().IsTupleDeclaration()) {
             if (!rightNode.IsKind(SyntaxKind.TupleExpression)) {
               right = BuildDeconstructExpression(rightNode, right);
             }
@@ -2855,6 +2872,11 @@ namespace CSharpLua {
         var propertySymbol = (IPropertySymbol)symbol;
         isField = IsPropertyField(node, propertySymbol);
         isReadOnly = propertySymbol.IsReadOnly;
+        if (IsPropertyTemplate(propertySymbol)) {
+          var (get, set) = Utility.GetPropertyTemplateFromAttribute(symbol);
+          LuaIdentifierNameSyntax fieldName = GetMemberName(symbol);
+          return new LuaPropertyTemplateExpressionSyntax(get, set);
+        }
       } else {
         var eventSymbol = (IEventSymbol)symbol;
         isField = IsEventField(eventSymbol);

--- a/CSharp.lua/LuaSyntaxNodeTransform.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.cs
@@ -1566,7 +1566,7 @@ namespace CSharpLua {
       bool isPreventDebugConcatenation = IsPreventDebug && operatorToken == LuaSyntaxNode.Tokens.Concatenation;
       if (left is LuaPropertyTemplateExpressionSyntax propertyTemplate) {
         var arguments = propertyTemplate.GetArguments(propertyTemplate.GetExpression.Binary(operatorToken, right));
-        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments);
+        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments, propertyTemplate.Name);
       } else if (left is LuaPropertyAdapterExpressionSyntax propertyAdapter) {
         LuaExpressionSyntax expression = null;
         var getter = propertyAdapter.GetCloneOfGet();
@@ -1621,7 +1621,7 @@ namespace CSharpLua {
         var expr = isPlus
           ? propertyTemplate.GetExpression.Plus(right)
           : propertyTemplate.GetExpression.Sub(right);
-        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, propertyTemplate.GetArguments(expr));
+        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, propertyTemplate.GetArguments(expr), propertyTemplate.Name);
       }
 
       if (left is LuaPropertyAdapterExpressionSyntax propertyAdapter) {
@@ -1642,7 +1642,7 @@ namespace CSharpLua {
       if (left is LuaPropertyTemplateExpressionSyntax propertyTemplate) {
         var invocation = new LuaInvocationExpressionSyntax(methodName, propertyTemplate.GetExpression, right);
         var arguments = propertyTemplate.GetArguments(invocation);
-        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments);
+        return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments, propertyTemplate.Name);
       } else if (left is LuaPropertyAdapterExpressionSyntax propertyAdapter) {
         var invocation = new LuaInvocationExpressionSyntax(methodName, propertyAdapter.GetCloneOfGet(), right);
         propertyAdapter.ArgumentList.AddArgument(invocation);
@@ -1862,7 +1862,7 @@ namespace CSharpLua {
           var right = VisitExpression(rightNode);
           if (left is LuaPropertyTemplateExpressionSyntax propertyTemplate) {
               var arguments = propertyTemplate.GetArguments(right);
-              return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments);
+              return BuildCodeTemplateExpression(propertyTemplate.SetTemplate, arguments, propertyTemplate.Name);
           } else if (leftNode.Kind().IsTupleDeclaration()) {
             if (!rightNode.IsKind(SyntaxKind.TupleExpression)) {
               right = BuildDeconstructExpression(rightNode, right);
@@ -2874,7 +2874,6 @@ namespace CSharpLua {
         isReadOnly = propertySymbol.IsReadOnly;
         if (IsPropertyTemplate(propertySymbol)) {
           var (get, set) = Utility.GetPropertyTemplateFromAttribute(symbol);
-          LuaIdentifierNameSyntax fieldName = GetMemberName(symbol);
           return new LuaPropertyTemplateExpressionSyntax(get, set);
         }
       } else {

--- a/CSharp.lua/Utils.cs
+++ b/CSharp.lua/Utils.cs
@@ -594,21 +594,41 @@ namespace CSharpLua {
           node = node.Parent.Parent;
         }
         if (node.HasCSharpLuaAttribute(LuaDocumentStatement.AttributeFlags.Template, out string text)) {
-          return GetCodeTemplateFromAttributeText(text);
+          return GetCodeTemplateFromAttributeText(text, codeTemplateAttributeRegex_);
         }
       } else {
         string xml = symbol.GetDocumentationCommentXml();
         if (xml != null) {
-          return GetCodeTemplateFromAttributeText(xml);
+          return GetCodeTemplateFromAttributeText(xml, codeTemplateAttributeRegex_);
         }
       }
       return null;
     }
 
-    private static readonly Regex codeTemplateAttributeRegex_ = new(@"@CSharpLua.Template\s*=\s*(.+)\s*", RegexOptions.Compiled);
+    public static (string get, string set) GetPropertyTemplateFromAttribute(this ISymbol symbol) {
+      var node = symbol.GetDeclaringSyntaxNode();
+      string get = null;
+      string set = null;
+      if (node != null) {
+        if (symbol.Kind == SymbolKind.Field) {
+          node = node.Parent.Parent;
+        }
+        if (node.HasCSharpLuaAttribute(LuaDocumentStatement.AttributeFlags.Get, out string getText)) {
+          get = GetCodeTemplateFromAttributeText(getText, codeGetAttributeRegex_);
+        }
+        if (node.HasCSharpLuaAttribute(LuaDocumentStatement.AttributeFlags.Set, out string setText)) {
+          set = GetCodeTemplateFromAttributeText(setText, codeSetAttributeRegex_);
+        }
+      }
+      return (get, set);
+    }
 
-    private static string GetCodeTemplateFromAttributeText(string document) {
-      var matches = codeTemplateAttributeRegex_.Matches(document);
+    private static readonly Regex codeTemplateAttributeRegex_ = new(@"@CSharpLua.Template\s*=\s*(.+)\s*", RegexOptions.Compiled);
+    private static readonly Regex codeGetAttributeRegex_ = new(@"@CSharpLua.Get\s*=\s*(.+)\s*", RegexOptions.Compiled);
+    private static readonly Regex codeSetAttributeRegex_ = new(@"@CSharpLua.Set\s*=\s*(.+)\s*", RegexOptions.Compiled);
+
+    private static string GetCodeTemplateFromAttributeText(string document, Regex regex) {
+      var matches = regex.Matches(document);
       if (matches.Count > 0) {
         string text = matches[0].Groups[1].Value;
         return text.Trim().Trim('"');

--- a/test/BridgeNetTests/Batch1/src/Constants.cs
+++ b/test/BridgeNetTests/Batch1/src/Constants.cs
@@ -112,6 +112,8 @@
         public const string MODULE_RUNTIME = "Runtime helpers"; // + "Array";
         public const string MODULE_IO = "IO";
 
+        public const string MODULE_TEMPLATES = "@CSharpLua templates";
+
         public const string IGNORE_DATE = null;
     }
 }

--- a/test/BridgeNetTests/Batch1/src/Templates/ConversionTemplateTests.cs
+++ b/test/BridgeNetTests/Batch1/src/Templates/ConversionTemplateTests.cs
@@ -1,0 +1,43 @@
+using Bridge.ClientTest;
+using Bridge.Test.NUnit;
+
+namespace Batch1.src.Templates
+{
+    [Category(Constants.MODULE_TEMPLATES)]
+    [TestFixture(TestNameFormat = "Conversion templates - {0}")]
+    public class ConversionTemplateTests
+    {
+        [Test]
+        public void TestImplicitCast()
+        {
+            var type1 = new Type1();
+            Type2 type2 = type1;
+
+            // Type didn't actually change due to the template
+            Assert.AreEqual($"{nameof(ConversionTemplateTests)}+{nameof(Type1)}", type2.GetType().Name);
+        }
+
+        [Test]
+        public void TestExplicitCast()
+        {
+            var type2 = new Type2();
+            var type1 = (Type1)type2;
+
+            // Type didn't actually change due to the template
+            Assert.AreEqual($"{nameof(ConversionTemplateTests)}+{nameof(Type2)}", type1.GetType().Name);
+        }
+
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+        private class Type1
+        {
+            /// @CSharpLua.Template = "{0}"
+            public static extern implicit operator Type2(Type1 t);
+        }
+
+        private class Type2
+        {
+            /// @CSharpLua.Template = "{0}"
+            public static extern explicit operator Type1(Type2 t);
+        }
+    }
+}

--- a/test/BridgeNetTests/Batch1/src/Templates/PropertyTemplateTests.cs
+++ b/test/BridgeNetTests/Batch1/src/Templates/PropertyTemplateTests.cs
@@ -202,22 +202,22 @@ namespace Batch1.src.Templates
             /// @CSharpLua.Set = "a = {0}"
             public static extern int StaticProp { get; set; }
 
-            /// @CSharpLua.Get = "{0}.CustomProp1"
-            /// @CSharpLua.Set = "{0}.CustomProp1 = {1}"
+            /// @CSharpLua.Get = "{this}.CustomProp1"
+            /// @CSharpLua.Set = "{this}.CustomProp1 = {0}"
             public extern int FullProp { get; set; }
-            /// @CSharpLua.Get = "{0}.CustomProp2"
+            /// @CSharpLua.Get = "{this}.CustomProp2"
             public extern int GetProp { get; set; }
-            /// @CSharpLua.Set = "{0}.CustomProp2 = {1}"
+            /// @CSharpLua.Set = "{this}.CustomProp2 = {0}"
             public extern int SetProp { get; set; }
             /// @CSharpLua.Get = "4"
             public extern int GetOnlyProp { get; }
 
-            /// @CSharpLua.Get = "{0}.StringProp"
-            /// @CSharpLua.Set = "{0}.StringProp = {1}"
+            /// @CSharpLua.Get = "{this}.CustomProp3"
+            /// @CSharpLua.Set = "{this}.CustomProp3 = {0}"
             public extern string StringProp { get; set; }
 
-            /// @CSharpLua.Get = "{0}.NullableProp"
-            /// @CSharpLua.Set = "{0}.NullableProp = {1}"
+            /// @CSharpLua.Get = "{this}.CustomProp4"
+            /// @CSharpLua.Set = "{this}.CustomProp4 = {0}"
             public extern int? NullableProp { get; set; }
         }
     }

--- a/test/BridgeNetTests/Batch1/src/Templates/PropertyTemplateTests.cs
+++ b/test/BridgeNetTests/Batch1/src/Templates/PropertyTemplateTests.cs
@@ -1,0 +1,224 @@
+using Bridge.ClientTest;
+using Bridge.Test.NUnit;
+
+namespace Batch1.src.Templates
+{
+    [Category(Constants.MODULE_TEMPLATES)]
+    [TestFixture(TestNameFormat = "Property templates - {0}")]
+    public class TemplatePropertyTest
+    {
+        [Test]
+        public static void PropertyTemplateGetSetTest()
+        {
+            var test = new TestType();
+            for (var i = 0; i < 10; i++)
+            {
+                test.FullProp = i;
+                Assert.AreEqual(i, test.FullProp);
+            }
+        }
+
+        [Test]
+        public static void PropertyTemplateGetOnlySetOnlyTest()
+        {
+            var test = new TestType();
+            for (var i = 0; i < 10; i++)
+            {
+                test.SetProp = i;
+                Assert.AreEqual(i, test.GetProp);
+            }
+        }
+
+        [Test]
+        public static void PropertyTemplateGetOnlyTest()
+        {
+            var test = new TestType();
+            Assert.AreEqual(4, test.GetOnlyProp);
+        }
+
+        [Test]
+        public static void StaticPropertyTemplateGetSetTest()
+        {
+            var a = 5;
+            Assert.AreEqual(5, a);
+            TestType.StaticProp = 7;
+            Assert.AreEqual(7, TestType.StaticProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateIncrementTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 4
+            };
+            test.FullProp++;
+            Assert.AreEqual(5, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateDecrementTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 4
+            };
+            test.FullProp--;
+            Assert.AreEqual(3, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateAddTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 4
+            };
+            test.FullProp += 4;
+            Assert.AreEqual(8, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateSubtractTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 4
+            };
+            test.FullProp -= 9;
+            Assert.AreEqual(-5, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateMultiplyTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 4
+            };
+            test.FullProp *= 5;
+            Assert.AreEqual(20, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateDivideTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 4
+            };
+            test.FullProp /= 3;
+            Assert.AreEqual(1, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateModuloTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 13
+            };
+            test.FullProp %= 10;
+            Assert.AreEqual(3, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateBitwiseAndTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 3
+            };
+            test.FullProp &= 5;
+            Assert.AreEqual(1, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateBitwiseOrTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 3
+            };
+            test.FullProp |= 5;
+            Assert.AreEqual(7, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateLeftShiftTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 5
+            };
+            test.FullProp <<= 4;
+            Assert.AreEqual(80, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateRightShiftTest()
+        {
+            var test = new TestType
+            {
+                FullProp = 800
+            };
+            test.FullProp >>= 4;
+            Assert.AreEqual(50, test.FullProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateConcatenateTest()
+        {
+            var test = new TestType
+            {
+                StringProp = "foo"
+            };
+            test.StringProp += "bar";
+            Assert.AreEqual("foobar", test.StringProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateNullCoallesceTest()
+        {
+            var test = new TestType();
+            test.StringProp ??= "hello world";
+            Assert.AreEqual("hello world", test.StringProp);
+        }
+
+        [Test]
+        public static void PropertyTemplateNullableTest()
+        {
+            var test = new TestType();
+            Assert.False(test.NullableProp.HasValue);
+            test.NullableProp = 5;
+            Assert.True(test.NullableProp.HasValue);
+            Assert.AreEqual(5, test.NullableProp.Value);
+        }
+
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+        private class TestType
+        {
+            /// @CSharpLua.Get = "a"
+            /// @CSharpLua.Set = "a = {0}"
+            public static extern int StaticProp { get; set; }
+
+            /// @CSharpLua.Get = "{0}.CustomProp1"
+            /// @CSharpLua.Set = "{0}.CustomProp1 = {1}"
+            public extern int FullProp { get; set; }
+            /// @CSharpLua.Get = "{0}.CustomProp2"
+            public extern int GetProp { get; set; }
+            /// @CSharpLua.Set = "{0}.CustomProp2 = {1}"
+            public extern int SetProp { get; set; }
+            /// @CSharpLua.Get = "4"
+            public extern int GetOnlyProp { get; }
+
+            /// @CSharpLua.Get = "{0}.StringProp"
+            /// @CSharpLua.Set = "{0}.StringProp = {1}"
+            public extern string StringProp { get; set; }
+
+            /// @CSharpLua.Get = "{0}.NullableProp"
+            /// @CSharpLua.Set = "{0}.NullableProp = {1}"
+            public extern int? NullableProp { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I wrote this code about a ago, so forgive me if my memories on the specifics are a bit vague.

What this does is add functionality for writing something like this:
```csharp
public class Unit
{
	/// @CSharpLua.Get = "GetWidgetLife({0})"
	/// @CSharpLua.Set = "SetWidgetLife({0}, {1})"
	public float Life { get; set; }
}

public class Program
{
	public static void Main()
	{
		var u = CreateUnit(...);
		// TRANSPILED TO: SetWidgetLife(u, GetWidgetLife(u) + 50);
		u.Life += 50;
	}
}
```

This allows for more compact and natural C# programming, despite the way in which WC3's API is exposed to Lua.

The other change is for being able to use `@CSharpLua.Template` on explicit/implicit operators. I probably don't need this anymore, but I don't really remember what I changed for it either, maybe nothing? I figured I'd add tests for it anyway.

I tried to follow the existing design as much as possible, but did get a bit lost at times, so feel free to suggest ways of improving it.