### PR TITLE
Expand Math, add MathF

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Math.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Math.lua
@@ -19,10 +19,93 @@ local trunc = System.trunc
 
 local math = math
 local floor = math.floor
+local ceil = math.ceil
 local min = math.min
 local max = math.max
 local abs = math.abs
 local log = math.log
+local sqrt = math.sqrt
+local ln2 = log(2)
+
+local function acosh(a)
+  return log(a + sqrt(a ^ 2 - 1))
+end
+
+local function asinh(a)
+  return log(a + sqrt(a ^ 2 + 1))
+end
+
+local function atanh(a)
+  return 0.5 * log((1 + a) / (1 - a))
+end
+
+local function cbrt(a)
+  if a >= 0 then
+    return a ^ (1 / 3)
+  else
+    return -abs(a) ^ (1 / 3) 
+  end
+end
+
+local function copySign(a, b)
+  if b >= 0 then
+    return a >= 0 and a or -a
+  else
+    return a >= 0 and -a or a
+  end
+end
+
+local function fusedMultiplyAdd(a, b, c)
+  return a * b + c
+end
+
+local function ilogB(a)
+  return a == 0 and -2147483648 or floor(log(abs(a)) / ln2)
+end
+
+local function log2(a)
+  return log(a) / ln2
+end
+
+local function maxMagnitude(a, b)
+  local x = abs(a)
+  local y = abs(b)
+  if x > y then
+    return a
+  elseif x < y then
+    return b
+  else
+    return a > b and a or b
+  end
+end
+
+local function minMagnitude(a, b)
+  local x = abs(a)
+  local y = abs(b)
+  if x < y then
+    return a
+  elseif x > y then
+    return b
+  else
+    return a < b and a or b
+  end
+end
+
+local function reciprocalEstimate(a)
+  return 1 / a
+end
+
+local function reciprocalSqrtEstimate(a)
+  return sqrt(1 / a)
+end
+
+local function scaleB(a, b)
+  return a * 2 ^ b
+end
+
+local function sinCos(a)
+  return System.ValueTuple(math.sin(a), math.cos(a))
+end
 
 local function bigMul(a, b)
   return a * b
@@ -38,11 +121,17 @@ local function round(value, digits, mode)
   local i = value * mult
   if mode == 1 then
     value = trunc(i + (value >= 0 and 0.5 or -0.5))
+  elseif mode == 2 then
+    value = i >= 0 and floor(i) or ceil(i)
+  elseif mode == 3 then
+    value = floor(i)
+  elseif mode == 4 then
+    value = ceil(i)
   else
     value = trunc(i)
     if value ~= i then
       local dif = i - value
-      if value >= 0 then
+      if i >= 0 then
         if dif > 0.5 or (dif == 0.5 and value % 2 ~= 0) then
           value = value + 1  
         end
@@ -115,30 +204,45 @@ local tanh = math.tanh or function (x) return sinh(x) / cosh(x) end
 local Math = math
 Math.Abs = abs
 Math.Acos = math.acos
+Math.Acosh = acosh
 Math.Asin = math.asin
+Math.Asinh = asinh
 Math.Atan = math.atan
+Math.Atanh = atanh
 Math.Atan2 = math.atan2 or math.atan
 Math.BigMul = bigMul
-Math.Ceiling = math.ceil
+Math.Cbrt = cbrt
+Math.Ceiling = ceil
 Math.Clamp = clamp
+Math.CopySign = copySign
 Math.Cos = math.cos
 Math.Cosh = cosh
 Math.DivRem = divRem
 Math.Exp = exp
-Math.Floor = math.floor
+Math.Floor = floor
+Math.FusedMultiplyAdd = fusedMultiplyAdd
 Math.IEEERemainder = IEEERemainder
+Math.ILogB = ilogB
 Math.Log = log
 Math.Log10 = log10
-Math.Max = math.max
-Math.Min = math.min
+Math.Log2 = log2
+Math.Max = max
+Math.MaxMagnitude = maxMagnitude
+Math.Min = min
+Math.MinMagnitude = minMagnitude
 Math.Pow = pow
+Math.ReciprocalEstimate = reciprocalEstimate
+Math.ReciprocalSqrtEstimate = reciprocalSqrtEstimate
 Math.Round = round
+Math.ScaleB = scaleB
 Math.Sign = sign
 Math.Sin = math.sin
+Math.SinCos = sinCos
 Math.Sinh = sinh
-Math.Sqrt = math.sqrt
+Math.Sqrt = sqrt
 Math.Tan = math.tan
 Math.Tanh = tanh
 Math.Truncate = truncate
 
 System.define("System.Math", Math)
+System.define("System.MathF", Math)

--- a/test/BridgeNetTests/Batch1/src/MathTests.cs
+++ b/test/BridgeNetTests/Batch1/src/MathTests.cs
@@ -813,5 +813,260 @@ namespace Bridge.ClientTest
         //    // #1629
         //    Assert.AreEqual(Math.BigMul(214748364, 214748364), 46116859840676496L);
         //}
+
+        [Test]
+        public void RoundDoubleAround0Works()
+        {
+            // Test around 0 for all rounding modes
+            NumberHelper.AssertDouble(-1, Math.Round(-0.7, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(0, Math.Round(-0.5, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(0, Math.Round(-0.3, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(0, Math.Round(0.3, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(0, Math.Round(0.5, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(1, Math.Round(0.7, 0, MidpointRounding.ToEven));
+
+            NumberHelper.AssertDouble(-1, Math.Round(-0.7, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(-1, Math.Round(-0.5, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(0, Math.Round(-0.3, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(0, Math.Round(0.3, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(1, Math.Round(0.5, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(1, Math.Round(0.7, 0, MidpointRounding.AwayFromZero));
+
+            NumberHelper.AssertDouble(0, Math.Round(-0.7, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(0, Math.Round(-0.5, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(0, Math.Round(-0.3, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(0, Math.Round(0.3, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(0, Math.Round(0.5, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(0, Math.Round(0.7, 0, MidpointRounding.ToZero));
+
+            NumberHelper.AssertDouble(-1, Math.Round(-0.7, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(-1, Math.Round(-0.5, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(-1, Math.Round(-0.3, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(0, Math.Round(0.3, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(0, Math.Round(0.5, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(0, Math.Round(0.7, 0, MidpointRounding.ToNegativeInfinity));
+
+            NumberHelper.AssertDouble(0, Math.Round(-0.7, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(0, Math.Round(-0.5, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(0, Math.Round(-0.3, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(1, Math.Round(0.3, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(1, Math.Round(0.5, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(1, Math.Round(0.7, 0, MidpointRounding.ToPositiveInfinity));
+
+            // Test around the first even number as well
+            NumberHelper.AssertDouble(-2, Math.Round(-1.7, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(-2, Math.Round(-1.5, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(-1, Math.Round(-1.3, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(1, Math.Round(1.3, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(2, Math.Round(1.5, 0, MidpointRounding.ToEven));
+            NumberHelper.AssertDouble(2, Math.Round(1.7, 0, MidpointRounding.ToEven));
+
+            NumberHelper.AssertDouble(-2, Math.Round(-1.7, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(-2, Math.Round(-1.5, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(-1, Math.Round(-1.3, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(1, Math.Round(1.3, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(2, Math.Round(1.5, 0, MidpointRounding.AwayFromZero));
+            NumberHelper.AssertDouble(2, Math.Round(1.7, 0, MidpointRounding.AwayFromZero));
+
+            NumberHelper.AssertDouble(-1, Math.Round(-1.7, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(-1, Math.Round(-1.5, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(-1, Math.Round(-1.3, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(1, Math.Round(1.3, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(1, Math.Round(1.5, 0, MidpointRounding.ToZero));
+            NumberHelper.AssertDouble(1, Math.Round(1.7, 0, MidpointRounding.ToZero));
+
+            NumberHelper.AssertDouble(-2, Math.Round(-1.7, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(-2, Math.Round(-1.5, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(-2, Math.Round(-1.3, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(1, Math.Round(1.3, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(1, Math.Round(1.5, 0, MidpointRounding.ToNegativeInfinity));
+            NumberHelper.AssertDouble(1, Math.Round(1.7, 0, MidpointRounding.ToNegativeInfinity));
+
+            NumberHelper.AssertDouble(-1, Math.Round(-1.7, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(-1, Math.Round(-1.5, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(-1, Math.Round(-1.3, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(2, Math.Round(1.3, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(2, Math.Round(1.5, 0, MidpointRounding.ToPositiveInfinity));
+            NumberHelper.AssertDouble(2, Math.Round(1.7, 0, MidpointRounding.ToPositiveInfinity));
+        }
+
+        [Test]
+        public void AcoshWorks()
+        {
+            Assert.AreEqual(double.NaN, Math.Acosh(0));
+            Assert.AreEqual(double.NaN, Math.Acosh(0.5));
+            NumberHelper.AssertDouble(0, Math.Acosh(1));
+            NumberHelper.AssertDoubleWithEpsilon8(1.3169578969248166, Math.Acosh(2));
+            NumberHelper.AssertDoubleWithEpsilon8(1.762747174039086, Math.Acosh(3));
+            NumberHelper.AssertDoubleWithEpsilon8(2.0634370688955608, Math.Acosh(4));
+        }
+
+        [Test]
+        public void AsinhWorks()
+        {
+            NumberHelper.AssertDoubleWithEpsilon8(-1.4436354751788103, Math.Asinh(-2));
+            NumberHelper.AssertDoubleWithEpsilon8(-0.881373587019543, Math.Asinh(-1));
+            NumberHelper.AssertDouble(0, Math.Asinh(0));
+            NumberHelper.AssertDoubleWithEpsilon8(0.881373587019543, Math.Asinh(1));
+            NumberHelper.AssertDoubleWithEpsilon8(1.4436354751788103, Math.Asinh(2));
+            NumberHelper.AssertDoubleWithEpsilon8(1.8184464592320668, Math.Asinh(3));
+            NumberHelper.AssertDoubleWithEpsilon8(2.0947125472611012, Math.Asinh(4));
+        }
+
+        [Test]
+        public void AtanhWorks()
+        {
+            Assert.AreEqual(double.NegativeInfinity, Math.Atanh(-1));
+            NumberHelper.AssertDoubleWithEpsilon8(-0.9729550745276566, Math.Atanh(-0.75));
+            NumberHelper.AssertDouble(0, Math.Atanh(0));
+            NumberHelper.AssertDoubleWithEpsilon8(0.5493061443340548, Math.Atanh(0.5));
+            Assert.AreEqual(double.PositiveInfinity, Math.Atanh(1));
+        }
+
+        [Test]
+        public void CbrtWorks()
+        {
+            NumberHelper.AssertDoubleWithEpsilon8(-1.7099759466766968, Math.Cbrt(-5));
+            NumberHelper.AssertDouble(0, Math.Cbrt(0));
+            NumberHelper.AssertDoubleWithEpsilon8(0.7937005259840998, Math.Cbrt(0.5));
+            NumberHelper.AssertDouble(1, Math.Cbrt(1));
+            NumberHelper.AssertDoubleWithEpsilon8(2.1544346900318834, Math.Cbrt(10));
+            NumberHelper.AssertDouble(3, Math.Cbrt(27));
+        }
+
+        [Test]
+        public void CopySignWorks()
+        {
+            NumberHelper.AssertDouble(5, Math.CopySign(5, 7));
+            NumberHelper.AssertDouble(-5, Math.CopySign(5, -7));
+            NumberHelper.AssertDouble(5, Math.CopySign(-5, 7));
+            NumberHelper.AssertDouble(-5, Math.CopySign(-5, -7));
+
+            NumberHelper.AssertDouble(8, Math.CopySign(8, 4));
+            NumberHelper.AssertDouble(-8, Math.CopySign(8, -4));
+            NumberHelper.AssertDouble(8, Math.CopySign(-8, 4));
+            NumberHelper.AssertDouble(-8, Math.CopySign(-8, -4));
+        }
+
+        [Test]
+        public void FusedMultipleAddWorks()
+        {
+            NumberHelper.AssertDouble(26, Math.FusedMultiplyAdd(4, 5, 6));
+            NumberHelper.AssertDoubleWithEpsilon8(9.85, Math.FusedMultiplyAdd(2.5, 2.7, 3.1));
+            NumberHelper.AssertDoubleWithEpsilon8(35.507, Math.FusedMultiplyAdd(6.18, 4.15, 9.86));
+        }
+
+        [Test]
+        public void ILogBWorks()
+        {
+            NumberHelper.AssertDouble(4, Math.ILogB(-27));
+            NumberHelper.AssertDouble(1, Math.ILogB(-3));
+            NumberHelper.AssertDouble(-14, Math.ILogB(-0.0001));
+            NumberHelper.AssertDouble(int.MinValue, Math.ILogB(0));
+            NumberHelper.AssertDouble(-8, Math.ILogB(0.005));
+            NumberHelper.AssertDouble(2, Math.ILogB(6));
+            NumberHelper.AssertDouble(9, Math.ILogB(581));
+        }
+
+        [Test]
+        public void Log2Works()
+        {
+            Assert.AreEqual(double.NaN, Math.Log2(-27));
+            Assert.AreEqual(double.NaN, Math.Log2(-3));
+            Assert.AreEqual(double.NaN, Math.Log2(-0.0001));
+            Assert.AreEqual(double.NegativeInfinity, Math.Log2(0));
+            NumberHelper.AssertDoubleWithEpsilon8(-7.643856189774724, Math.Log2(0.005));
+            NumberHelper.AssertDoubleWithEpsilon8(2.584962500721156, Math.Log2(6));
+            NumberHelper.AssertDoubleWithEpsilon8(9.18239435340453, Math.Log2(581));
+        }
+
+        [Test]
+        public void MaxMagnitudeWorks()
+        {
+            NumberHelper.AssertDouble(40, Math.MaxMagnitude(40, 40));
+            NumberHelper.AssertDouble(40, Math.MaxMagnitude(40, -40));
+            NumberHelper.AssertDouble(40, Math.MaxMagnitude(-40, 40));
+            NumberHelper.AssertDouble(-40, Math.MaxMagnitude(-40, -40));
+
+            NumberHelper.AssertDouble(41, Math.MaxMagnitude(40, 41));
+            NumberHelper.AssertDouble(-41, Math.MaxMagnitude(40, -41));
+            NumberHelper.AssertDouble(41, Math.MaxMagnitude(-40, 41));
+            NumberHelper.AssertDouble(-41, Math.MaxMagnitude(-40, -41));
+
+            NumberHelper.AssertDouble(41, Math.MaxMagnitude(41, 40));
+            NumberHelper.AssertDouble(41, Math.MaxMagnitude(41, -40));
+            NumberHelper.AssertDouble(-41, Math.MaxMagnitude(-41, 40));
+            NumberHelper.AssertDouble(-41, Math.MaxMagnitude(-41, -40));
+        }
+
+        [Test]
+        public void MinMagnitudeWorks()
+        {
+            NumberHelper.AssertDouble(40, Math.MinMagnitude(40, 40));
+            NumberHelper.AssertDouble(-40, Math.MinMagnitude(40, -40));
+            NumberHelper.AssertDouble(-40, Math.MinMagnitude(-40, 40));
+            NumberHelper.AssertDouble(-40, Math.MinMagnitude(-40, -40));
+
+            NumberHelper.AssertDouble(39, Math.MinMagnitude(40, 39));
+            NumberHelper.AssertDouble(-39, Math.MinMagnitude(40, -39));
+            NumberHelper.AssertDouble(39, Math.MinMagnitude(-40, 39));
+            NumberHelper.AssertDouble(-39, Math.MinMagnitude(-40, -39));
+
+            NumberHelper.AssertDouble(39, Math.MinMagnitude(39, 40));
+            NumberHelper.AssertDouble(39, Math.MinMagnitude(39, -40));
+            NumberHelper.AssertDouble(-39, Math.MinMagnitude(-39, 40));
+            NumberHelper.AssertDouble(-39, Math.MinMagnitude(-39, -40));
+        }
+
+        [Test]
+        public void ReciprocalEstimateWorks()
+        {
+            NumberHelper.AssertDoubleWithEpsilon8(-0.14285714285714285, Math.ReciprocalEstimate(-7));
+            NumberHelper.AssertDouble(-2, Math.ReciprocalEstimate(-0.5));
+            Assert.AreEqual(double.PositiveInfinity, Math.ReciprocalEstimate(0));
+            NumberHelper.AssertDoubleWithEpsilon8(4.761904761904762, Math.ReciprocalEstimate(0.21));
+            NumberHelper.AssertDouble(1, Math.ReciprocalEstimate(1));
+            NumberHelper.AssertDoubleWithEpsilon8(0.3333333333333333, Math.ReciprocalEstimate(3));
+            NumberHelper.AssertDoubleWithEpsilon8(0.0022172949002217295, Math.ReciprocalEstimate(451));
+        }
+
+        [Test]
+        public void ReciprocalSqrtEstimateWorks()
+        {
+            Assert.AreEqual(double.NaN, Math.ReciprocalSqrtEstimate(-7));
+            Assert.AreEqual(double.NaN, Math.ReciprocalSqrtEstimate(-0.5));
+            Assert.AreEqual(double.PositiveInfinity, Math.ReciprocalSqrtEstimate(0));
+            NumberHelper.AssertDoubleWithEpsilon8(2.1821789023599236, Math.ReciprocalSqrtEstimate(0.21));
+            NumberHelper.AssertDouble(1, Math.ReciprocalSqrtEstimate(1));
+            NumberHelper.AssertDoubleWithEpsilon8(0.5773502691896258, Math.ReciprocalSqrtEstimate(3));
+            NumberHelper.AssertDoubleWithEpsilon8(0.04708816093480111, Math.ReciprocalSqrtEstimate(451));
+        }
+
+        [Test]
+        public void ScaleBWorks()
+        {
+            NumberHelper.AssertDouble(56, Math.ScaleB(7, 3));
+            NumberHelper.AssertDouble(9, Math.ScaleB(72, -3));
+            NumberHelper.AssertDouble(-139264, Math.ScaleB(-17, 13));
+            NumberHelper.AssertDoubleWithEpsilon8(-0.0032958984375, Math.ScaleB(-27, -13));
+        }
+
+        [Test]
+        public void SinCosWorks()
+        {
+            var (sin, cos) = Math.SinCos(5);
+            NumberHelper.AssertDoubleWithEpsilon8(-0.9589242746631385, sin);
+            NumberHelper.AssertDoubleWithEpsilon8(0.28366218546322625, cos);
+
+            (sin, cos) = Math.SinCos(-3);
+            NumberHelper.AssertDoubleWithEpsilon8(-0.1411200080598672, sin);
+            NumberHelper.AssertDoubleWithEpsilon8(-0.9899924966004454, cos);
+        }
+
+        [Test]
+        public void MathFWorks()
+        {
+            Assert.AreEqual(5, MathF.Abs(-5));
+        }
     }
 }


### PR DESCRIPTION
Added:
- Acosh
- Asinh
- Atanh
- Cbrt
- CopySign
- FusedMultiplyAdd
- ILogB
- Log2
- MaxMagnitude
- MinMagnitude
- ReciprocalEstimate
- ReciprocalSqrtEstimate
- ScaleB
- SinCos

Additionally:
- Fixes `MidpointRounding.ToEven` between -1 and -0.5 (see https://github.com/yanghuan/CSharp.lua/pull/434)
- Adds support for `MidpointRounding.ToZero`, `MidpointRounding.ToNegativeInfinity` and `MidpointRounding.ToPositiveInfinity`
- Adds MathF as a redirect to Math (should all be identical)