### PR TITLE
Add handling for digit base64 character

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Convert.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Convert.lua
@@ -493,7 +493,7 @@ local function fromBase64ComputeResultLength(s, len)
 end
 
 local function FromBase64Decode(s, len, t, resultLength)
-  local i, j, codes, c, gotoEqualityCharEncountered = 1, 0, 0x000000ff
+  local i, j, codes, c, gotoEqualityCharEncountered = 1, 0, 0x000000ff, 0, false
   while true do
     if i > len then
       break
@@ -506,6 +506,8 @@ local function FromBase64Decode(s, len, t, resultLength)
       elseif c <= 122 then
         c = c - 71 
       end
+    elseif c >= 48 then
+      c = c + 4
     else
       if c == 43 then
         c = 62


### PR DESCRIPTION
I wasn't able to understand the remaining issue with the base64 implementation. I think it has to do with clearing the remaining data in `codes` to the output since a long base64 sequence appears truncated after round-trip and a short base64 sequence results in an empty string.

Progress on https://github.com/yanghuan/CSharp.lua/issues/441.

Feel free to reject this if you want a full implementation but this is one step that could help. 