### PR TITLE
Fix HashSet UnionWith

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/HashSet.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/HashSet.lua
@@ -123,7 +123,7 @@ local HashSet = {
       throw(ArgumentNullException("other"))
     end
     local count = 0
-    for _, v in each(collection) do
+    for _, v in each(other) do
       v = wrap(v)
       if this[v] == nil then
         this[v] = true


### PR DESCRIPTION
```csharp
        var a = new HashSet<int> { 1 };
        var b = new HashSet<int> { 2 };
        a.UnionWith(b);
        Console.WriteLine(a.Count);
```

Error:
```
C:\Users\joelv\Downloads\lua-5.3.6_Win64_bin\lua53.exe: System.NullReferenceException: Object reference not set to an instance of an object.
stack traceback:
        .\out.lua:8768: in method 'UnionWith'
        .\out.lua:20772: in field 'Main'
        .\out.lua:20842: in main chunk
        [C]: in function 'require'
        .\main.lua:1: in main chunk
        [C]: in ?
```

After PR, the output is `2` as expected (2 items: `1`, and `2`)