### PR TITLE
Add support for bitwise operators on Lua 5.2

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Core.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Core.lua
@@ -496,9 +496,14 @@ if version < 5.3 then
   local bnot, band, bor, xor, sl, sr
   local bit = rawget(global, "bit")
   if not bit then
-    local ok, b = pcall(require, "bit")
-    if ok then
-      bit = b
+    local b32 = rawget(global, "bit32")
+    if not b32 then
+      local ok, b = pcall(require, "bit")
+      if ok then
+        bit = b
+      end
+    else
+      bit = b32
     end
   end
   if bit then


### PR DESCRIPTION
I don't see mentions of Lua 5.2 in the docs much, but this can help bitwise operators work on Lua 5.2 with the usage of the `bit32` built-in library. This is useful for Factorio extensions which run in Lua 5.2.