### PR TITLE
Allow null (unset) static field in classic mode

### DIFF
--- a/CSharp.lua/LuaSyntaxGenerator.cs
+++ b/CSharp.lua/LuaSyntaxGenerator.cs
@@ -1766,11 +1766,10 @@ namespace CSharpLua {
 
     private bool IsStaticCtorField(ISymbol symbol) {
       if (Setting.IsClassic && symbol.IsStatic && symbol.Kind == SymbolKind.Field) {
-        Contract.Assert(symbol.IsFromCode());
         var field = (IFieldSymbol)symbol;
         if (!field.IsConst && !field.Type.IsImmutable() && (field.IsReadOnly || IsPrivate(symbol))) {
           var variableDeclarator = (VariableDeclaratorSyntax)field.GetDeclaringSyntaxNode();
-          if (variableDeclarator.Initializer?.Value.IsNull() == false) {
+          if (variableDeclarator?.Initializer?.Value.IsNull() == false) {
             return true;
           }
         }


### PR DESCRIPTION
Currently the generated backing field fails the "IsFromCode" assertion

Resolves https://github.com/yanghuan/CSharp.lua/issues/453