### PR TITLE
Add support for Linq.Order and Linq.OrderDescending

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
@@ -464,7 +464,21 @@ function Enumerable.OrderBy(source, keySelector, comparer, TKey)
   return orderBy(source, keySelector, comparer, TKey, false)
 end
 
+function Enumerable.Order(source, comparer, TKey)
+  local function keySelector(x)
+    return x
+  end
+  return orderBy(source, keySelector, comparer, TKey, false)
+end
+
 function Enumerable.OrderByDescending(source, keySelector, comparer, TKey)
+  return orderBy(source, keySelector, comparer, TKey, true)
+end
+
+function Enumerable.OrderDescending(source, comparer, TKey)
+  local function keySelector(x)
+    return x
+  end
   return orderBy(source, keySelector, comparer, TKey, true)
 end
 

--- a/CSharp.lua/System.xml
+++ b/CSharp.lua/System.xml
@@ -714,8 +714,12 @@ limitations under the License.
         <method name="OfType" Template="Linq.OfType({0}, {`0})" />
         <method name="OrderBy" ArgCount="2" Template="Linq.OrderBy({0}, {1}, nil, {`1})" />
         <method name="OrderBy" ArgCount="3" Template="Linq.OrderBy({0}, {1}, {2}, {`1})" />
+        <method name="Order" ArgCount="1" Template="Linq.Order({0}, nil, {`0})" />
+        <method name="Order" ArgCount="2" Template="Linq.Order({0}, {1}, {`0})" />
         <method name="OrderByDescending" ArgCount="2" Template="Linq.OrderByDescending({0}, {1}, nil, {`1})" />
         <method name="OrderByDescending" ArgCount="3" Template="Linq.OrderByDescending({0}, {1}, {2}, {`1})" />
+        <method name="OrderDescending" ArgCount="1" Template="Linq.OrderDescending({0}, nil, {`0})" />
+        <method name="OrderDescending" ArgCount="2" Template="Linq.OrderDescending({0}, {1}, {`0})" />
         <method name="ThenBy" ArgCount="2" Template="Linq.ThenBy({0}, {1}, nil, {`1})" />
         <method name="ThenBy" ArgCount="3" Template="Linq.ThenBy({0}, {1}, {2}, {`1})" />
         <method name="ThenByDescending" ArgCount="2" Template="Linq.ThenByDescending({0}, {1}, nil, {`1})" />


### PR DESCRIPTION
Introduced in .NET 7.

`Order` - https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.order?view=net-8.0
`OrderDescending` - https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.orderdescending?view=net-8.0