### PR TITLE
Add Linq.MinBy and Linq.MaxBy support

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
@@ -1259,7 +1259,6 @@ function Enumerable.Max(source, ...)
 end
 
 local function minByOrMaxBy(compareFn, source, keySelector, comparer, TSource, TKey)
-  print("x")
   if source == nil then throw(ArgumentNullException("source")) end
   if keySelector == nil then throw(ArgumentNullException("keySelector")) end
   if comparer == nil then

--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
@@ -1258,6 +1258,52 @@ function Enumerable.Max(source, ...)
   return minOrMax(maxFn, source, ...)
 end
 
+local function minByOrMaxBy(compareFn, source, keySelector, comparer, T)
+  if source == nil then throw(ArgumentNullException("source")) end
+  if keySelector == nil then throw(ArgumentNullException("keySelector")) end
+  if comparer == nil then
+    comparer = Comparer_1(T).getDefault()
+  end
+  local compare = comparer.Compare
+  local key = T:default()
+  local item;
+  if key == nil then
+    for _, x in each(source) do
+      xKey = keySelector(x)
+      if xKey ~= nil and (key == nil or compareFn(compare, comparer, xKey, key)) then
+        key = xKey
+        item = x
+      end 
+    end
+    return item
+  else
+    local hasItem = false
+    for _, x in each(source) do
+      xKey = keySelector(x)
+      if hasItem then
+        if compareFn(compare, comparer, xKey, key) then
+          key = xKey
+          item = x
+        end
+      else
+        key = xKey
+        item = x
+        hasItem = true
+      end
+    end
+    if hasItem then return item end
+    throw(InvalidOperationException("NoElements"))
+  end
+end
+
+function Enumerable.MinBy(source, keySelector, comparer, T)
+  return minByOrMaxBy(minFn, source, keySelector, comparer, T)
+end
+
+function Enumerable.MaxBy(source, keySelector, comparer, T)
+  return minByOrMaxBy(maxFn, source, keySelector, comparer, T)
+end
+
 function Enumerable.Average(source, ...)
   if source == nil then throw(ArgumentNullException("source")) end
   local sum, count = 0, 0

--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
@@ -1258,50 +1258,45 @@ function Enumerable.Max(source, ...)
   return minOrMax(maxFn, source, ...)
 end
 
-local function minByOrMaxBy(compareFn, source, keySelector, comparer, T)
+local function minByOrMaxBy(compareFn, source, keySelector, comparer, TSource, TKey)
+  print("x")
   if source == nil then throw(ArgumentNullException("source")) end
   if keySelector == nil then throw(ArgumentNullException("keySelector")) end
   if comparer == nil then
-    comparer = Comparer_1(T).getDefault()
+    comparer = Comparer_1(TKey).getDefault()
   end
   local compare = comparer.Compare
-  local key = T:default()
-  local item;
-  if key == nil then
-    for _, x in each(source) do
-      xKey = keySelector(x)
-      if xKey ~= nil and (key == nil or compareFn(compare, comparer, xKey, key)) then
+  local key = TKey:default()
+  local item = TSource:default()
+  local hasItem = false
+  for _, x in each(source) do
+    local xKey = keySelector(x)
+    if hasItem then
+      if compareFn(compare, comparer, xKey, key) then
         key = xKey
         item = x
-      end 
-    end
-    return item
-  else
-    local hasItem = false
-    for _, x in each(source) do
-      xKey = keySelector(x)
-      if hasItem then
-        if compareFn(compare, comparer, xKey, key) then
-          key = xKey
-          item = x
-        end
-      else
-        key = xKey
-        item = x
-        hasItem = true
       end
+    else
+      key = xKey
+      item = x
+      hasItem = true
     end
-    if hasItem then return item end
+  end
+  if hasItem then
+    return item
+  elseif item == nil then
+    return nil
+  else
     throw(InvalidOperationException("NoElements"))
   end
 end
 
-function Enumerable.MinBy(source, keySelector, comparer, T)
-  return minByOrMaxBy(minFn, source, keySelector, comparer, T)
+function Enumerable.MinBy(source, keySelector, comparer, TSource, TKey)
+  return minByOrMaxBy(minFn, source, keySelector, comparer, TSource, TKey)
 end
 
-function Enumerable.MaxBy(source, keySelector, comparer, T)
-  return minByOrMaxBy(maxFn, source, keySelector, comparer, T)
+function Enumerable.MaxBy(source, keySelector, comparer, TSource, TKey)
+  return minByOrMaxBy(maxFn, source, keySelector, comparer, TSource, TKey)
 end
 
 function Enumerable.Average(source, ...)

--- a/CSharp.lua/System.xml
+++ b/CSharp.lua/System.xml
@@ -711,10 +711,10 @@ limitations under the License.
         <method name="Max" ArgCount="2" RetType="System.Double" Template="Linq.Max({0}, {1}, System.Double)" />
         <method name="Max" ArgCount="2" RetType="System.Decimal" Template="Linq.Max({0}, {1}, System.Double)" />
         <method name="Max" ArgCount="2" GenericArgCount="2" Template="Linq.Max({0}, {1}, {`1})" />
-        <method name="MinBy" ArgCount="2" GenericArgCount="2" Template="Linq.MinBy({0}, {1}, nil, {`1})" />
-        <method name="MinBy" ArgCount="3" GenericArgCount="2" Template="Linq.MinBy({0}, {1}, {2}, {`1})" />
-        <method name="MaxBy" ArgCount="2" GenericArgCount="2" Template="Linq.MaxBy({0}, {1}, nil, {`1})" />
-        <method name="MaxBy" ArgCount="3" GenericArgCount="2" Template="Linq.MaxBy({0}, {1}, {2}, {`1})" />
+        <method name="MinBy" ArgCount="2" GenericArgCount="2" Template="Linq.MinBy({0}, {1}, nil, {`0}, {`1})" />
+        <method name="MinBy" ArgCount="3" GenericArgCount="2" Template="Linq.MinBy({0}, {1}, {2}, {`0}, {`1})" />
+        <method name="MaxBy" ArgCount="2" GenericArgCount="2" Template="Linq.MaxBy({0}, {1}, nil, {`0}, {`1})" />
+        <method name="MaxBy" ArgCount="3" GenericArgCount="2" Template="Linq.MaxBy({0}, {1}, {2}, {`0}, {`1})" />
         <method name="OfType" Template="Linq.OfType({0}, {`0})" />
         <method name="OrderBy" ArgCount="2" Template="Linq.OrderBy({0}, {1}, nil, {`1})" />
         <method name="OrderBy" ArgCount="3" Template="Linq.OrderBy({0}, {1}, {2}, {`1})" />

--- a/CSharp.lua/System.xml
+++ b/CSharp.lua/System.xml
@@ -711,6 +711,10 @@ limitations under the License.
         <method name="Max" ArgCount="2" RetType="System.Double" Template="Linq.Max({0}, {1}, System.Double)" />
         <method name="Max" ArgCount="2" RetType="System.Decimal" Template="Linq.Max({0}, {1}, System.Double)" />
         <method name="Max" ArgCount="2" GenericArgCount="2" Template="Linq.Max({0}, {1}, {`1})" />
+        <method name="MinBy" ArgCount="2" GenericArgCount="2" Template="Linq.MinBy({0}, {1}, nil, {`1})" />
+        <method name="MinBy" ArgCount="3" GenericArgCount="2" Template="Linq.MinBy({0}, {1}, {2}, {`1})" />
+        <method name="MaxBy" ArgCount="2" GenericArgCount="2" Template="Linq.MaxBy({0}, {1}, nil, {`1})" />
+        <method name="MaxBy" ArgCount="3" GenericArgCount="2" Template="Linq.MaxBy({0}, {1}, {2}, {`1})" />
         <method name="OfType" Template="Linq.OfType({0}, {`0})" />
         <method name="OrderBy" ArgCount="2" Template="Linq.OrderBy({0}, {1}, nil, {`1})" />
         <method name="OrderBy" ArgCount="3" Template="Linq.OrderBy({0}, {1}, {2}, {`1})" />


### PR DESCRIPTION
This is my test app. Works same as .NET from what I can tell.

```csharp
internal class Program
{
    private static void Main(string[] args)
    {
        var comparer = new LeastSignificantDigitComparer();
        var people = new[] { new Person("Age 5", 5), new Person("Age 19", 19), new Person("Age 51", 51), new Person("Age 2", 2), new Person("Age 3", 3) };

        Console.WriteLine(people.MinBy(x => x.Age)!.Name);
        Console.WriteLine(people.MaxBy(x => x.Age)!.Name);
        Console.WriteLine("---");
        Console.WriteLine(people.MinBy(x => x.Age, comparer)!.Name);
        Console.WriteLine(people.MaxBy(x => x.Age, comparer)!.Name);
    }
}

class Person
{
    public Person(string name, int age)
    {
        Name = name;
        Age = age;
    }

    public string Name { get; }
    public int Age { get; }
}

public class LeastSignificantDigitComparer : IComparer<int>
{
    public int Compare(int x, int y)
    {
        var xD = x % 10;
        var yD = y % 10;
        return xD.CompareTo(yD);
    }
}
```

Output:
```
Age 2
Age 51
---
Age 51
Age 19
```