### PR TITLE
Fix Linq.Single with predicate

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Collections/Linq.lua
@@ -1019,7 +1019,7 @@ local function single(source, ...)
         found = true
       end
     end
-    if foun then return true, result end    
+    if found then return true, result end    
     return false, 0    
   end
 end


### PR DESCRIPTION
Small typo in existing implementation when using a predicate.