### PR TITLE
Allow coroutine to be undefined for partial Array usage

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/Array.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/Array.lua
@@ -50,9 +50,14 @@ local pack = table.pack
 local unpack = table.unpack
 local error = error
 local coroutine = coroutine
-local ccreate = coroutine.create
-local cresume = coroutine.resume
-local cyield = coroutine.yield
+local ccreate
+local cresume
+local cyield
+if coroutine ~= nil then
+  ccreate = coroutine.create
+  cresume = coroutine.resume
+  cyield = coroutine.yield
+end
 
 local null = {}
 local arrayEnumerator


### PR DESCRIPTION
Some runtimes have coroutines disabled, for example Factorio (source: https://lua-api.factorio.com/1.1.101/auxiliary/libraries.html#modified-functions). This allows coroutine related locals to be `nil` without preventing the entire `Array.lua` module from failing to load.