### PR TITLE
Improvements to for loop handling

### DIFF
--- a/CSharp.lua/LuaSyntaxNodeTransform.Helper.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.Helper.cs
@@ -1572,32 +1572,24 @@ namespace CSharpLua {
       return false;
     }
 
-    private bool IsNumericalForLess(SyntaxKind kind, out bool isLess) {
+    private bool IsNumericalForLess(SyntaxKind kind) {
       switch (kind) {
         case SyntaxKind.NotEqualsExpression:
         case SyntaxKind.LessThanExpression:
-          isLess = true;
-          return true;
         case SyntaxKind.LessThanOrEqualExpression:
-          isLess = false;
           return true;
         default:
-          isLess = false;
           return false;
       }
     }
 
-    private bool IsNumericalForGreater(SyntaxKind kind, out bool isGreater) {
+    private bool IsNumericalForGreater(SyntaxKind kind) {
       switch (kind) {
         case SyntaxKind.NotEqualsExpression:
         case SyntaxKind.GreaterThanExpression:
-          isGreater = true;
-          return true;
         case SyntaxKind.GreaterThanOrEqualExpression:
-          isGreater = false;
           return true;
         default:
-          isGreater = false;
           return false;
       }
     }
@@ -1802,6 +1794,22 @@ namespace CSharpLua {
         goto Fail;
       }
 
+      if (conditionKind is SyntaxKind.GreaterThanExpression or SyntaxKind.LessThanExpression) {
+        var typeInfo = semanticModel_.GetTypeInfo(node.Declaration.Type);
+        if (!Utility.IsCastIntegerType(typeInfo.Type))
+          goto Fail;
+      }
+
+      foreach (var descendant in node.Statement.DescendantNodesAndSelf()) {
+        if (descendant is PostfixUnaryExpressionSyntax postfix) {
+          if (postfix.Operand is IdentifierNameSyntax name && variable.Identifier.ValueText == name.Identifier.ValueText)
+            goto Fail;
+        } else if (descendant is ArgumentSyntax argument) {
+          if (argument.RefKindKeyword != default)
+            goto Fail;
+        }
+      }
+
       var condition = (BinaryExpressionSyntax)node.Condition;
       if (!IsNumericalForVariableMatch(condition.Left, variable.Identifier)) {
         goto Fail;
@@ -1813,7 +1821,6 @@ namespace CSharpLua {
       }
 
       LuaExpressionSyntax stepExpression;
-      bool hasNoEqual;
       var increment = node.Incrementors.First();
       switch (increment.Kind()) {
         case SyntaxKind.PreIncrementExpression:
@@ -1830,12 +1837,12 @@ namespace CSharpLua {
             goto Fail;
           }
           if (increment.IsKind(SyntaxKind.PreIncrementExpression) || increment.IsKind(SyntaxKind.PostIncrementExpression)) {
-            if (!IsNumericalForLess(conditionKind, out hasNoEqual)) {
+            if (!IsNumericalForLess(conditionKind)) {
               goto Fail;
             }
             stepExpression = 1;
           } else {
-            if (!IsNumericalForGreater(conditionKind, out hasNoEqual)) {
+            if (!IsNumericalForGreater(conditionKind)) {
               goto Fail;
             }
             stepExpression = -1;
@@ -1855,11 +1862,11 @@ namespace CSharpLua {
           }
 
           if (increment.IsKind(SyntaxKind.AddAssignmentExpression)) {
-            if (!IsNumericalForLess(conditionKind, out hasNoEqual)) {
+            if (!IsNumericalForLess(conditionKind)) {
               goto Fail;
             }
           } else {
-            if (!IsNumericalForGreater(conditionKind, out hasNoEqual)) {
+            if (!IsNumericalForGreater(conditionKind)) {
               goto Fail;
             }
             if (stepExpression is LuaNumberLiteralExpressionSyntax numberLiteral) {
@@ -1881,21 +1888,18 @@ namespace CSharpLua {
       CheckLocalVariableName(ref identifier, variable);
 
       var startExpression = variable.Initializer.Value.AcceptExpression(this);
-      if (hasNoEqual) {
+
+      if (conditionKind == SyntaxKind.GreaterThanExpression) {
         if (limitExpression is LuaNumberLiteralExpressionSyntax limitLiteral) {
-          if (stepExpression is LuaNumberLiteralExpressionSyntax numberLiteral) {
-            limitExpression = new LuaIdentifierLiteralExpressionSyntax((limitLiteral.Number - numberLiteral.Number).ToString());
-          } else {
-            limitExpression = limitExpression.Sub(stepExpression);
-          }
+          limitExpression = limitLiteral.Number + 1;
         } else {
-          if (stepExpression is LuaNumberLiteralExpressionSyntax numberLiteral) {
-            limitExpression = numberLiteral.Number > 0
-              ? limitExpression.Sub(stepExpression)
-              : limitExpression.Plus((-numberLiteral.Number).ToString());
-          } else {
-            limitExpression = limitExpression.Sub(stepExpression);
-          }
+          limitExpression = limitExpression.Plus(1);
+        }
+      } else if (conditionKind == SyntaxKind.LessThanExpression) {
+        if (limitExpression is LuaNumberLiteralExpressionSyntax limitLiteral) {
+          limitExpression = limitLiteral.Number - 1;
+        } else {
+          limitExpression = limitExpression.Sub(1);
         }
       }
 

--- a/CSharp.lua/LuaSyntaxNodeTransform.Helper.cs
+++ b/CSharp.lua/LuaSyntaxNodeTransform.Helper.cs
@@ -1804,6 +1804,9 @@ namespace CSharpLua {
         if (descendant is PostfixUnaryExpressionSyntax postfix) {
           if (postfix.Operand is IdentifierNameSyntax name && variable.Identifier.ValueText == name.Identifier.ValueText)
             goto Fail;
+        } else if (descendant is AssignmentExpressionSyntax assignment) {
+          if (assignment.Left is IdentifierNameSyntax name && variable.Identifier.ValueText == name.Identifier.ValueText)
+            goto Fail;
         } else if (descendant is ArgumentSyntax argument) {
           if (argument.RefKindKeyword != default)
             goto Fail;

--- a/test/BridgeNetTests/Batch1/src/BasicCSharp/TestForLoop.cs
+++ b/test/BridgeNetTests/Batch1/src/BasicCSharp/TestForLoop.cs
@@ -1,0 +1,257 @@
+using Bridge.Test.NUnit;
+using System.Collections.Generic;
+
+namespace Bridge.ClientTest.BasicCSharp
+{
+    [Category(Constants.MODULE_BASIC_CSHARP)]
+    [TestFixture(TestNameFormat = "For loop - {0}")]
+    public class TestForLoop
+    {
+        [Test]
+        public static void TestLiteralNoEqualStep1()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < 5; i++)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
+        }
+
+        [Test]
+        public static void TestLiteralNoEqualStepNeg1()
+        {
+            var list = new List<int>();
+            for (var i = 5; i > 0; i--)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 5, 4, 3, 2, 1 }, list);
+        }
+
+        [Test]
+        public static void TestLiteralEqualStep1()
+        {
+            var list = new List<int>();
+            for (var i = 0; i <= 5; i++)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4, 5 }, list);
+        }
+
+        [Test]
+        public static void TestLiteralEqualStepNeg1()
+        {
+            var list = new List<int>();
+            for (var i = 5; i >= 0; i--)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 5, 4, 3, 2, 1, 0 }, list);
+        }
+
+        [Test]
+        public static void TestLiteralNoEqualStep2()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < 5; i += 2)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 2, 4 }, list);
+        }
+
+        [Test]
+        public static void TestLiteralNoEqualStepNeg2()
+        {
+            var list = new List<int>();
+            for (var i = 5; i > 0; i -= 2)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 5, 3, 1 }, list);
+        }
+
+        [Test]
+        public static void TestLiteralEqualStep2()
+        {
+            var list = new List<int>();
+            for (var i = 0; i <= 5; i += 2)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 2, 4 }, list);
+        }
+
+        [Test]
+        public static void TestLiteralEqualStepNeg2()
+        {
+            var list = new List<int>();
+            for (var i = 5; i >= 0; i -= 2)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 5, 3, 1 }, list);
+        }
+
+        [Test]
+        public static void TestExprNoEqualStep1()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < Expr(5); i += Expr(1))
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
+        }
+
+        [Test]
+        public static void TestExprNoEqualStepNeg1()
+        {
+            var list = new List<int>();
+            for (var i = 5; i > Expr(0); i -= Expr(1))
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 5, 4, 3, 2, 1 }, list);
+        }
+
+        [Test]
+        public static void TestExprEqualStep1()
+        {
+            var list = new List<int>();
+            for (var i = 0; i <= Expr(5); i += Expr(1))
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4, 5 }, list);
+        }
+
+        [Test]
+        public static void TestExprEqualStepNeg1()
+        {
+            var list = new List<int>();
+            for (var i = 5; i >= Expr(0); i -= Expr(1))
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 5, 4, 3, 2, 1, 0 }, list);
+        }
+
+        [Test]
+        public static void TestExprNoEqualStep2()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < Expr(5); i += Expr(2))
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 2, 4 }, list);
+        }
+
+        [Test]
+        public static void TestExprNoEqualStepNeg2()
+        {
+            var list = new List<int>();
+            for (var i = 5; i > Expr(0); i -= Expr(2))
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 5, 3, 1 }, list);
+        }
+
+        [Test]
+        public static void TestExprEqualStep2()
+        {
+            var list = new List<int>();
+            for (var i = 0; i <= Expr(5); i += Expr(2))
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 2, 4 }, list);
+        }
+
+        [Test]
+        public static void TestExprEqualStepNeg2()
+        {
+            var list = new List<int>();
+            for (var i = 5; i >= Expr(0); i -= Expr(2))
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new int[] { 5, 3, 1 }, list);
+        }
+
+        [Test]
+        public static void TestWithNonInt()
+        {
+            var list = new List<double>();
+            for (double i = 0; i < 1; i += 0.2)
+            {
+                list.Add(i);
+            }
+            Assert.AreDeepEqual(new double[] { 0, 0.2, 0.4, 0.6, 0.8 }, list);
+        }
+
+        [Test]
+        public static void TestWithModifying()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < 5; i += 2)
+            {
+                list.Add(i);
+                i--;
+            }
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
+        }
+
+        [Test]
+        public static void TestWithModifyingNoBlock()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < 5; i += 2)
+                list.Add(i--);
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
+        }
+
+        [Test]
+        public static void TestWithOut()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < 5; i += 2)
+            {
+                list.Add(i);
+                OutDec(i, out i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
+        }
+
+        [Test]
+        public static void TestWithRef()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < 5; i += 2)
+            {
+                list.Add(i);
+                RefDec(ref i);
+            }
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
+        }
+
+        public static int Expr(int number)
+        {
+            return number;
+        }
+
+        public static void OutDec(int numberIn, out int numberOut)
+        {
+            numberOut = numberIn - 1;
+        }
+
+        public static void RefDec(ref int number)
+        {
+            number--;
+        }
+    }
+}

--- a/test/BridgeNetTests/Batch1/src/BasicCSharp/TestForLoop.cs
+++ b/test/BridgeNetTests/Batch1/src/BasicCSharp/TestForLoop.cs
@@ -195,7 +195,16 @@ namespace Bridge.ClientTest.BasicCSharp
         }
 
         [Test]
-        public static void TestWithModifying()
+        public static void TestWithIncrementNoBlock()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < 5; i += 2)
+                list.Add(i--);
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
+        }
+
+        [Test]
+        public static void TestWithIncrement()
         {
             var list = new List<int>();
             for (var i = 0; i < 5; i += 2)
@@ -207,11 +216,26 @@ namespace Bridge.ClientTest.BasicCSharp
         }
 
         [Test]
-        public static void TestWithModifyingNoBlock()
+        public static void TestWithCompound()
         {
             var list = new List<int>();
             for (var i = 0; i < 5; i += 2)
-                list.Add(i--);
+            {
+                list.Add(i);
+                i -= 1;
+            }
+            Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
+        }
+
+        [Test]
+        public static void TestWithAssignment()
+        {
+            var list = new List<int>();
+            for (var i = 0; i < 5; i += 2)
+            {
+                list.Add(i);
+                i = 1 + i - 2;
+            }
             Assert.AreDeepEqual(new int[] { 0, 1, 2, 3, 4 }, list);
         }
 


### PR DESCRIPTION
The goals of this pull request were the following:
1. Fix issues with for loop step size and stop condition (e.g. `for (var i = 0; i < 8; i += 5)` would become `for i = 0, 3, 5` because it'd adjust the condition by the step size instead of 1). We now always adjust the end value by only 0, 1 or -1 according to the condition.
2. Switch to a while loop if the condition does not have an equals and the variable is a non-integer type, as neither the above nor the step size logic will not work for that (e.g. `for (var i = 0.0; i < 0.9; i += 0.2)`)
3. Switch to a while loop if the loop body makes any adjustments to the loop variable (`i--`, `i -= 5`, `i = i - 5`, `ref i`, `out i`).

Unfortunately, the `TestWithIncrementNoBlock` test produces an error that I do not know how to fix:

```
execute dotnet bin/Debug/PublishOutput/CSharp.lua.Launcher.dll -s ../Batch1/src -d ../Batch1/out -l ../BridgeAttributes/bin/Debug/net8.0/BridgeAttributes.dll!;../BridgeTestNUnit/bin/Debug/net8.0/BridgeTestNUnit.dll!;../ClientTestHelper/bin/Debug/net8.0/ClientTestHelper.dll! -a -metadata -c -module -csc /define:__JIT__;DEBUG;__LUAJIT202__
CSharpLua.BugErrorException: SourceLocation(../Batch1/src\BasicCSharp\TestForLoop.cs@201:13)"for (var i = 0; i < 5; i += 2)
                list.Add(i--);": Compiler has a bug, thanks to commit issue at https://github.com/yanghuan/CSharp.lua/issue
 ---> System.Diagnostics.Contracts.ContractException
 ---> System.ApplicationException
   at CSharpLua.LuaSyntaxGenerator.<>c.<.cctor>b__29_0(Object _, ContractFailedEventArgs e) in C:\Users\CSharp.lua\CSharp.lua\LuaSyntaxGenerator.cs:line 138
   at System.Runtime.CompilerServices.ContractHelper.RaiseContractFailedEvent(ContractFailureKind failureKind, String userMessage, String conditionText, Exception innerException)
   --- End of inner exception stack trace ---
   at System.Runtime.CompilerServices.ContractHelper.RaiseContractFailedEvent(ContractFailureKind failureKind, String userMessage, String conditionText, Exception innerException)
   at System.Diagnostics.Contracts.Contract.ReportFailure(ContractFailureKind failureKind, String userMessage, String conditionText, Exception innerException)
   at CSharpLua.LuaSyntaxNodeTransform.PopBlock() in C:\Users\CSharp.lua\CSharp.lua\LuaSyntaxNodeTransform.cs:line 192
   at CSharpLua.LuaSyntaxNodeTransform.VisitForStatement(ForStatementSyntax node) in C:\Users\CSharp.lua\CSharp.lua\LuaSyntaxNodeTransform.cs:line 5082
   at Microsoft.CodeAnalysis.CSharp.Syntax.ForStatementSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
   at CSharpLua.LuaSyntaxNodeTransform.BlockCommonNode.Visit(LuaSyntaxNodeTransform transform) in C:\Users\CSharp.lua\CSharp.lua\LuaSyntaxNodeTransform.cs:line 1356
   --- End of inner exception stack trace ---
   at CSharpLua.LuaSyntaxGenerator.Create(Boolean isSingleFile) in C:\Users\CSharp.lua\CSharp.lua\LuaSyntaxGenerator.cs:line 239
   at CSharpLua.LuaSyntaxGenerator.Generate(String outFolder) in C:\Users\CSharp.lua\CSharp.lua\LuaSyntaxGenerator.cs:line 267
   at CSharpLua.Compiler.Compile() in C:\Users\CSharp.lua\CSharp.lua\Compiler.cs:line 124
   at CSharpLua.Program.Main(String[] args) in C:\Users\CSharp.lua\CSharp.lua.Launcher\Program.cs:line 92
../../__bin/Lua/lua.exe: ...s\CSharp.lua\test\__bin\Lua\lua\run.lua:4: assertion failed!
stack traceback:
        [C]: in function 'assert'
        ...s\CSharp.lua\test\__bin\Lua\lua\run.lua:4: in function 'execute'
        ...s\CSharp.lua\test\__bin\Lua\lua\run.lua:60: in function 'compile'
        ...s\CSharp.lua\test\__bin\Lua\lua\run.lua:92: in function 'runAll'
        ...s\CSharp.lua\test\__bin\Lua\lua\run.lua:109: in function 'run'
        test.lua:23: in main chunk
        [C]: at 0x007d3360
```

Every other test should work fine, but it seems I will need some help to fix this last bug.