### PR TITLE
feat: add `MemoryExtensions.Contains`

### DIFF
--- a/CSharp.lua/CoreSystem.Lua/CoreSystem/MemoryExtensions.lua
+++ b/CSharp.lua/CoreSystem.Lua/CoreSystem/MemoryExtensions.lua
@@ -16,6 +16,7 @@ limitations under the License.
 
 local System = System
 local Span = System.Span
+local Array = System.Array
 
 System.MemoryExtensions = {
   AsSpan = function (array) 
@@ -25,5 +26,8 @@ System.MemoryExtensions = {
   AsBoundedSpan = function (array, start, length) 
     local SpanT = Span(array.__genericT__)
     return SpanT(array, start, length)
+  end,
+  Contains = function (span, value)
+    return Array.Contains(span._array, value)
   end
 }

--- a/test/BridgeNetTests/Batch1/src/MemoryExtensionsTests.cs
+++ b/test/BridgeNetTests/Batch1/src/MemoryExtensionsTests.cs
@@ -1,0 +1,18 @@
+using Bridge.Test.NUnit;
+using System;
+
+namespace Bridge.ClientTest
+{
+    [Category(Constants.MODULE_ARRAY)]
+    [TestFixture(TestNameFormat = "MemoryExtensions - {0}")]
+    public class MemoryExtensionsTests
+    {
+        [Test]
+        public void ContainsWorks()
+        {
+            var arr = new string[] { "x", "y" };
+            Assert.True(MemoryExtensions.Contains(arr, "x"));
+            Assert.False(MemoryExtensions.Contains(arr, "z"));
+        }
+    }
+}


### PR DESCRIPTION
Adds `MemoryExtensions.Contains` in preparation for [Span<T> and ReadOnlySpan<T> overloads are applicable in more scenarios in C# 14 and newer](https://github.com/dotnet/roslyn/blob/6091e3c5b402da54c1c28daee3aa42bc8beff230/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20DotNet%2010.md#spant-and-readonlyspant-overloads-are-applicable-in-more-scenarios-in-c-14-and-newer)

Created as draft as I'm running into an issue with the transpiler not picking up the implicit conversion from `T[]` to `Span<T>`. Based on the implementation, I'd expect the transpiled output to be:

```lua
local arr = ArrayString { "x", "y" }
local bar = System.MemoryExtensions.Contains(SpanString.ctorArray(arr), "x", System.String)
```

However, the output I'm seeing is

```lua
local arr = ArrayString { "x", "y" }
local bar = System.MemoryExtensions.Contains(arr, "x", System.String)
```

Any idea why this might be happening, or where I should look to address it?