### PR TITLE
tests: add test case for null-conditional access on templated property

### DIFF
--- a/test/BridgeNetTests/Batch1/src/Templates/PropertyTemplateTests.cs
+++ b/test/BridgeNetTests/Batch1/src/Templates/PropertyTemplateTests.cs
@@ -195,6 +195,14 @@ namespace Batch1.src.Templates
             Assert.AreEqual(5, test.NullableProp.Value);
         }
 
+        [Test]
+        public static void PropertyTemplateNullConditionalOperatorWorks()
+        {
+            TestType test = null;
+            var prop = test?.GetProp;
+            Assert.Null(prop);
+        }
+
 #pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
         private class TestType
         {


### PR DESCRIPTION
This PR adds a test case that serves as a bug report for incorrect handling of null-conditional access on templated properties.

Running BridgeNetTests/Tests fails with: `Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.`